### PR TITLE
ContextService convenience methods for completion stages

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -247,8 +247,8 @@
     <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.
 ]]>
                     </bottom>
-		    <docfilessubdirs>true</docfilessubdirs>
-
+                    <docfilessubdirs>true</docfilessubdirs>
+                    <source>1.8</source>
                 </configuration>
                 <executions>
                     <execution>

--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -1441,7 +1441,8 @@ within a task.
 The `jakarta.enterprise.concurrent.ContextService` allows applications to
 create contextual objects without using a managed executor. The
 `ContextService` uses the dynamic proxy capabilities found in the
-`java.lang.reflect` package to associate the application component
+`java.lang.reflect` package or creates proxy instances in a
+non-dynamic manner to associate the application component
 container context with an object instance. The object becomes a
 contextual object (see section 2.3.2 ) and whenever a method on the
 contextual object is invoked, the method executes with the thread
@@ -1485,7 +1486,7 @@ component’s environment for the resource type. For example, all
 `java:comp/env/concurrent` subcontext.
 
 * Contextual object proxy instances are created with a `ContextService`
-instance using the `createContextualProxy()` method. Contextual object
+instance using the `createContextualProxy()` or `contextual*()` methods. Contextual object
 proxies will run as an extension of the application component instance
 that created the proxy and may interact with Jakarta EE container resources
 as defined in other sections of this specification.


### PR DESCRIPTION
fixes #100 

This pull copies over the method signatures from org.eclipse.microprofile.context.ThreadContext, except for withContextCapture because that is covered as a separate issue.  I'm also updating doc to clarify that if the
user doesn't pass in a serializable instance in the first place, there should be no expectation that we make the
proxy serializable.  Serializable isn't useful for completion stage actions, just adds overhead, and wasn't a
requirement of the equivalent methods in MicroProfile.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>