### PR TITLE
completion stages backed by a context service

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -247,8 +247,8 @@
     <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.
 ]]>
                     </bottom>
-		    <docfilessubdirs>true</docfilessubdirs>
-
+                    <docfilessubdirs>true</docfilessubdirs>
+                    <source>1.8</source>
                 </configuration>
                 <executions>
                     <execution>

--- a/api/src/main/java/jakarta/enterprise/concurrent/ContextService.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ContextService.java
@@ -18,6 +18,8 @@ package jakarta.enterprise.concurrent;
 
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -458,4 +460,53 @@ public interface ContextService {
    *                                            {@code createContextualProxy} method.
    */
   public Map<String, String> getExecutionProperties(Object contextualProxy);
+
+  /**
+   * <p>Returns a new {@link java.util.concurrent.CompletableFuture} that is completed by the completion of the
+   * specified stage.</p>
+   *
+   * <p>The new completable future gets its default asynchronous execution facility from this <code>ContextService</code>,
+   * using the same {@link ManagedExecutorService} if this <code>ContextService</code>
+   * was obtained by {@link ManagedExecutorService#getContextService()}.</p>
+   *
+   * <p>When dependent stages are created from the new completable future,
+   * and from the dependent stages of those stages, and so on, thread context is captured
+   * and/or cleared by the <code>ContextService</code>. This guarantees that the action
+   * performed by each stage always runs under the thread context of the code that creates the stage,
+   * unless the user explicitly overrides by supplying a pre-contextualized action.</p>
+   *
+   * <p>Invocation of this method does not impact thread context propagation for the originally supplied
+   * completable future or any other dependent stages directly created from it (not using this method).</p>
+   *
+   * @param <T> completable future result type.
+   * @param stage a completable future whose completion triggers completion of the new completable
+   *        future that is created by this method.
+   * @return the new completable future.
+   */
+  public <T> CompletableFuture<T> withContextCapture(CompletableFuture<T> stage);
+
+  /**
+   * <p>Returns a new {@link java.util.concurrent.CompletionStage} that is completed by the completion of the
+   * specified stage.</p>
+   *
+   * <p>The new completion stage gets its default asynchronous execution facility from this <code>ContextService</code>,
+   * using the same {@link ManagedExecutorService} if this <code>ContextService</code>
+   * was obtained by {@link ManagedExecutorService#getContextService()},
+   * otherwise using the DefaultManagedExecutorService.</p>
+   *
+   * <p>When dependent stages are created from the new completion stage,
+   * and from the dependent stages of those stages, and so on, thread context is captured
+   * and/or cleared by the <code>ContextService</code>. This guarantees that the action
+   * performed by each stage always runs under the thread context of the code that creates the stage,
+   * unless the user explicitly overrides by supplying a pre-contextualized action.</p>
+   *
+   * <p>Invocation of this method does not impact thread context propagation for the originally supplied
+   * stage or any other dependent stages directly created from it (not using this method).</p>
+   *
+   * @param <T> completion stage result type.
+   * @param stage a completion stage whose completion triggers completion of the new stage
+   *        that is created by this method.
+   * @return the new completion stage.
+   */
+  public <T> CompletionStage<T> withContextCapture(CompletionStage<T> stage);
 }

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorService.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -167,5 +167,13 @@ import java.util.concurrent.ExecutorService;
  * @since 1.0
  */
 public interface ManagedExecutorService extends ExecutorService {
-
+    /**
+     * Returns a {@link ContextService} which has the same propagation settings as this <code>ManagedExecutorService</code>
+     * and uses this <code>ManagedExecutorService</code> as the default asynchronous execution facility for
+     * {@link java.util.concurrent.CompletionStage} and {@link java.util.concurrent.CompletableFuture} instances
+     * that it creates via the <code>withContextCapture</code> methods.
+     *
+     * @return a <code>ContextService</code> with the same propagation settings as this <code>ManagedExecutorService</code>.
+     */
+    public ContextService getContextService();
 }

--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -1441,7 +1441,8 @@ within a task.
 The `jakarta.enterprise.concurrent.ContextService` allows applications to
 create contextual objects without using a managed executor. The
 `ContextService` uses the dynamic proxy capabilities found in the
-`java.lang.reflect` package to associate the application component
+`java.lang.reflect` package or creates proxy instances in a
+non-dynamic manner to associate the application component
 container context with an object instance. The object becomes a
 contextual object (see section 2.3.2 ) and whenever a method on the
 contextual object is invoked, the method executes with the thread
@@ -1485,7 +1486,7 @@ component’s environment for the resource type. For example, all
 `java:comp/env/concurrent` subcontext.
 
 * Contextual object proxy instances are created with a `ContextService`
-instance using the `createContextualProxy()` method. Contextual object
+instance using the `createContextualProxy()` or `contextual*()` methods. Contextual object
 proxies will run as an extension of the application component instance
 that created the proxy and may interact with Jakarta EE container resources
 as defined in other sections of this specification.

--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -1491,6 +1491,10 @@ proxies will run as an extension of the application component instance
 that created the proxy and may interact with Jakarta EE container resources
 as defined in other sections of this specification.
 
+* Specialized contextual proxies for unmanaged `CompletionStage` and
+`CompletableFuture` instances are created with the `withContextCapture()`
+methods, enabling context propagation to all dependent stages.
+
 It is important for Application Component Providers to identify and
 document the required behaviors and service-level agreements for each
 required `ContextService`. The following example illustrates how the


### PR DESCRIPTION
fixes #101 

This copies over the ThreadContext.withContextCapture(CompletionStage) and ThreadContext.withContextCapture(CompletableFuture) method signatures from MicroProfile Context Propagation 1.2 (latest version).  Also part of this approach is the ManagedExecutor.getThreadContext() method signature.  The Jakarta/Java EE Concurrency equivalent for MicroProfile's ThreadContext class is the ContextService, so I have added a ManagedExecutorService.getContextService() equivalent under this pull to have the same purpose, which is to obtain an instance that is backed by the managed executor so that the managed executor can be the default asynchronous execution facility for completion stages that created via withContextCapture.  I'm making note of this here because it's the only place thus far where a method signature didn't translate exactly from MicroProfile to Jakarta EE Concurrency and needed some interpretation.  We are also free to decide if this piece isn't wanted, in which case we could simply omit the getContextService method altogether and just have withContextCapture completion stages be backed by java:comp/DefaultManagedExecutorService when they need to run async.

Also, I have chosen to make these changes as a commit layered on top of the commit for pull #138 issue #100 which updates ContextService with MicroProfile's CompletableFuture dependent stage action contextualization methods, which are a prerequisite of this pull due to discussion of the interaction with them in JavaDoc.  The layered commit reflects the prerequisite relationship.