### PR TITLE
managed ForkJoinWorkerThreadFactory for parallel stream operations with context

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactory.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactory.java
@@ -45,9 +45,9 @@ import java.util.concurrent.ThreadFactory;
  * will run with the application component context of the component instance
  * that created (looked-up) this ManagedThreadFactory instance.<p>
  *
- * Tasks that run on the {@link ForkJoinWorkerThread} that is created by the
+ * The {@link ForkJoinWorkerThread} that is created by the
  * {@link ForkJoinWorkerThreadFactory#newThread(ForkJoinPool)} method
- * run with the application component context of the component instance
+ * runs tasks with the application component context of the component instance
  * that created (looked-up) this ManagedThreadFactory instance.
  * The Jakarta EE Product Provider establishes the context once per
  * <code>ForkJoinWorkerThread</code> and does not reset the context


### PR DESCRIPTION
This is the most I can see us doing for #46 

It should be noted that the same issue for parallel stream support was also opened in MicroProfile https://github.com/eclipse/microprofile-context-propagation/issues/10 where there isn't a ManagedThreadFactory equivalent, and there is a discussion there of a more granular approach that is already possible -- in both specs -- without these changes.

Also, reference [this gist](https://gist.github.com/NottyCode/9c1663f814ca7e579f9a05e13afda418) (I worked with the author on the concept behind it) of how a user can manually contextualize a ForkJoinWorkerThreadFactory using existing API.  This pull simply formalizes that approach in declaring that the ManagedThreadFactory will provide it for you by also implementing the ForkJoinWorkerThreadFactory interface.

When reviewing this, some consideration should be given as to whether it is important to have this in the specification or whether the existing means are sufficient.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>