### PR TITLE
create resource definition annotations for Concurrency

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -332,6 +332,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13</version>

--- a/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.enterprise.concurrent;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.transaction.UserTransaction;
+
+/**
+ * <p>Defines a {@link ContextService}
+ * to be registered in JNDI by the container
+ * under the JNDI name that is specified in the
+ * {@link #name()} attribute.</p>
+ *
+ * <p>Application components can refer to this JNDI name in the
+ * {@link jakarta.annotation.Resource#lookup() lookup} attribute of a
+ * {@link jakarta.annotation.Resource} annotation,</p>
+ *
+ * <pre>{@literal @}ContextServiceDefinition(
+ *     name = "java:app/concurrent/MyContext",
+ *     propagated = APPLICATION,
+ *     unchanged = TRANSACTION,
+ *     cleared = ALL_REMAINING)
+ * public class MyServlet extends HttpServlet {
+ *    {@literal @}Resource(lookup = "java:app/concurrent/MyContext",
+ *               name = "java:app/concurrent/env/MyContextRef")
+ *     ContextService appContextSvc;
+ * </pre>
+ *
+ * <p>Resource environment references in a deployment descriptor
+ * can similarly specify the <code>lookup-name</code>,</p>
+ *
+ * <pre>
+ * &lt;resource-env-ref&gt;
+ *    &lt;resource-env-ref-name&gt;java:app/env/concurrent/MyContextRef&lt;/resource-env-ref-name&gt;
+ *    &lt;resource-env-ref-type&gt;javax.enterprise.concurrent.ContextService&lt;/resource-env-ref-type&gt;
+ *    &lt;lookup-name&gt;java:app/concurrent/MyContext&lt;/lookup-name&gt;
+ * &lt;/resource-env-ref&gt;
+ * </pre>
+ *
+ * <p>The {@link #cleared()}, {@link #propagated()}, and {@link #unchanged()}
+ * attributes enable the application to configure how thread context
+ * is applied to tasks and actions that are contextualized by the
+ * <code>ContextService</code>.
+ * Constants are provided on this class for context types that are
+ * defined by the Jakarta EE Concurrency specification.
+ * In addition to those constants, a Jakarta EE product provider
+ * may choose to accept additional vendor-specific context types.
+ * Usage of vendor-specific types will make applications non-portable.</p>
+ *
+ * <p>Overlap of the same context type across multiple lists is an error and
+ * prevents the <code>ContextService</code> instance from being created.
+ * If {@link #ALL_REMAINING} is not present in any of the lists, it is
+ * implicitly appended to the {@link #cleared()} context types.</p>
+ *
+ * @since 3.0
+ */
+// TODO could mention relation with <context-service> definition in deployment descriptor once that is added
+@Repeatable(ContextServiceDefinition.List.class)
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface ContextServiceDefinition {
+    /**
+     * <p>JNDI name of the {@link ContextService} instance being defined.
+     * The JNDI name must must be in a valid Jakarta EE namespace,
+     * such as,</p>
+     *
+     * <ul>
+     * <li>java:comp</li>
+     * <li>java:module</li>
+     * <li>java:app</li>
+     * <li>java:global</li>
+     * </ul>
+     *
+     * @return <code>ContextService</code> JNDI name.
+     */
+    String name();
+
+    /**
+     * <p>Types of context to clear whenever a thread runs the
+     * contextual task or action. The thread's previous context
+     * is restored afterward.
+     *
+     * <p>Constants are provided on this class for the context types
+     * that are defined by the Jakarta EE Concurrency specification.</p>
+     *
+     * @return context types to clear.
+     */
+    String[] cleared() default { TRANSACTION };
+
+    /**
+     * <p>Types of context to capture from the requesting thread
+     * and propagate to a thread that runs the contextual task
+     * or action.
+     * The captured context is re-established when threads
+     * run the contextual task or action, with the respective
+     * thread's previous context being restored afterward.
+     *
+     * <p>Constants are provided on this class for the context types
+     * that are defined by the Jakarta EE Concurrency specification.</p>
+     *
+     * @return context types to capture and propagate.
+     */
+    String[] propagated() default { ALL_REMAINING };
+
+    /**
+     * <p>Types of context that are left alone when a thread
+     * runs the contextual task or action.</p>
+     *
+     * <p>Constants are provided on this class for the context types
+     * that are defined by the Jakarta EE Concurrency specification.</p>
+     *
+     * @return context types to leave unchanged.
+     */
+    String[] unchanged() default {};
+
+    /**
+     * <p>All available thread context types that are not specified
+     * elsewhere.</p>
+     *
+     * <p>For example, to define a <code>ContextService</code> that
+     * propagates {@link #SECURITY} context,
+     * leaves {@link #TRANSACTION} context alone,
+     * and clears every other context type:</p>
+     *
+     * <pre>{@literal @}ContextServiceDefinition(
+     *     name = "java:module/concurrent/SecurityContext",
+     *     propagated = SECURITY,
+     *     unchanged = TRANSACTION,
+     *     cleared = ALL_REMAINING)
+     * public class MyServlet extends HttpServlet ...
+     * </pre>
+     */
+    static final String ALL_REMAINING = "Remaining";
+
+    /**
+     * <p>Context pertaining to the application component or module,
+     * including its Jakarta EE namespace (such as
+     * <code>java:comp/env/</code>) and thread context class loader.</p>
+     *
+     * <p>A cleared application context means that the thread is
+     * not associated with any application component and lacks
+     * access to the Jakarta EE namespace and thread context class
+     * loader of the application.</p>
+     */
+    static final String APPLICATION = "Application";
+
+    // TODO: CDI context is the topic of
+    // https://github.com/eclipse-ee4j/concurrency-api/issues/105
+
+    /**
+     * <p>Context that controls the credentials that are associated
+     * with the thread, including the caller subject and
+     * invocation/RunAs subject.</p>
+     *
+     * <p>A cleared security context gives the thread unauthenticated
+     * subjects.</p>
+     */
+    static final String SECURITY = "Security";
+
+    /**
+     * <p>Context that controls the transaction that is associated
+     * with the thread.</p>
+     *
+     * <p>A thread with a cleared transaction context can begin
+     * a new {@link jakarta.transaction.UserTransaction}.</p>
+     *
+     * <p>The execution property, {@link ManagedTask#TRANSACTION},
+     * if specified, takes precedence over the behavior for
+     * transaction context that is specified on the resource
+     * definition annotations.</p>
+     *
+     * <p>Jakarta EE providers need not support the propagation
+     * of transactions to other threads and can reject resource
+     * definition annotations that include transaction as a
+     * propagated context.</p>
+     */
+    // TODO the last item above is the topic of
+    // https://github.com/eclipse-ee4j/concurrency-api/issues/102
+    // and can be updated accordingly when that capability is added.
+    static final String TRANSACTION = "Transaction";
+
+    /**
+     * Enables multiple <code>ContextServiceDefinition</code>
+     * annotations on the same type.
+     */
+    @Retention(RUNTIME)
+    @Target(TYPE)
+    public @interface List {
+        ContextServiceDefinition[] value();
+    }
+}

--- a/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
@@ -52,7 +52,7 @@ import jakarta.transaction.UserTransaction;
  * <pre>
  * &lt;resource-env-ref&gt;
  *    &lt;resource-env-ref-name&gt;java:app/env/concurrent/MyContextRef&lt;/resource-env-ref-name&gt;
- *    &lt;resource-env-ref-type&gt;javax.enterprise.concurrent.ContextService&lt;/resource-env-ref-type&gt;
+ *    &lt;resource-env-ref-type&gt;jakarta.enterprise.concurrent.ContextService&lt;/resource-env-ref-type&gt;
  *    &lt;lookup-name&gt;java:app/concurrent/MyContext&lt;/lookup-name&gt;
  * &lt;/resource-env-ref&gt;
  * </pre>
@@ -81,7 +81,7 @@ import jakarta.transaction.UserTransaction;
 public @interface ContextServiceDefinition {
     /**
      * <p>JNDI name of the {@link ContextService} instance being defined.
-     * The JNDI name must must be in a valid Jakarta EE namespace,
+     * The JNDI name must be in a valid Jakarta EE namespace,
      * such as,</p>
      *
      * <ul>

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
@@ -52,7 +52,7 @@ import java.lang.annotation.Target;
  * <pre>
  * &lt;resource-env-ref&gt;
  *    &lt;resource-env-ref-name&gt;java:module/env/concurrent/MyExecutorRef&lt;/resource-env-ref-name&gt;
- *    &lt;resource-env-ref-type&gt;javax.enterprise.concurrent.ManagedExecutorService&lt;/resource-env-ref-type&gt;
+ *    &lt;resource-env-ref-type&gt;jakarta.enterprise.concurrent.ManagedExecutorService&lt;/resource-env-ref-type&gt;
  *    &lt;lookup-name&gt;java:module/concurrent/MyExecutor&lt;/lookup-name&gt;
  * &lt;/resource-env-ref&gt;
  * </pre>
@@ -66,7 +66,7 @@ import java.lang.annotation.Target;
 public @interface ManagedExecutorDefinition {
     /**
      * JNDI name of the {@link ManagedExecutorService} instance.
-     * The JNDI name must must be in a valid Jakarta EE namespace,
+     * The JNDI name must be in a valid Jakarta EE namespace,
      * such as,
      * <ul>
      * <li>java:comp</li>
@@ -96,7 +96,7 @@ public @interface ManagedExecutorDefinition {
      * <p>The amount of time in milliseconds that a task or action
      * can execute before it is considered hung.</p>
      *
-     * <p>The default value of <code>-1</code> indicates unknown.</p>
+     * <p>The default value of <code>-1</code> indicates unlimited.</p>
      *
      * @return number of milliseconds after which a task or action
      *         is considered hung.

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.enterprise.concurrent;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * <p>Defines a {@link ManagedExecutorService}
+ * to be registered in JNDI by the container
+ * under the JNDI name that is specified in the
+ * {@link #name()} attribute.</p>
+ *
+ * <p>Application components can refer to this JNDI name in the
+ * {@link jakarta.annotation.Resource#lookup() lookup} attribute of a
+ * {@link jakarta.annotation.Resource} annotation,</p>
+ *
+ * <pre>{@literal @}ManagedExecutorDefinition(
+ *     name = "java:module/concurrent/MyExecutor",
+ *     hungTaskThreshold = 120000,
+ *     maxAsync = 5,
+ *     context ={@literal @}ContextServiceDefinition(
+ *               name = "java:module/concurrent/MyExecutorContext",
+ *               propagated = { SECURITY, APPLICATION }))
+ * public class MyServlet extends HttpServlet {
+ *    {@literal @}Resource(lookup = "java:module/concurrent/MyExecutor",
+ *               name = "java:module/concurrent/env/MyExecutorRef")
+ *     ManagedExecutorService myExecutor;
+ * </pre>
+ *
+ * <p>Resource environment references in a deployment descriptor
+ * can similarly specify the <code>lookup-name</code>,</p>
+ *
+ * <pre>
+ * &lt;resource-env-ref&gt;
+ *    &lt;resource-env-ref-name&gt;java:module/env/concurrent/MyExecutorRef&lt;/resource-env-ref-name&gt;
+ *    &lt;resource-env-ref-type&gt;javax.enterprise.concurrent.ManagedExecutorService&lt;/resource-env-ref-type&gt;
+ *    &lt;lookup-name&gt;java:module/concurrent/MyExecutor&lt;/lookup-name&gt;
+ * &lt;/resource-env-ref&gt;
+ * </pre>
+ *
+ * @since 3.0
+ */
+//TODO could mention relation with <managed-executor> definition in deployment descriptor once that is added
+@Repeatable(ManagedExecutorDefinition.List.class)
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface ManagedExecutorDefinition {
+    /**
+     * JNDI name of the {@link ManagedExecutorService} instance.
+     * The JNDI name must must be in a valid Jakarta EE namespace,
+     * such as,
+     * <ul>
+     * <li>java:comp</li>
+     * <li>java:module</li>
+     * <li>java:app</li>
+     * <li>java:global</li>
+     * </ul>
+     *
+     * @return <code>ManagedExecutorService</code> JNDI name.
+     */
+    String name();
+
+    /**
+     * <p>Determines how context is applied to tasks and actions that
+     * run on this executor.</p>
+     *
+     * <p>The default value indicates to use the default instance of
+     * {@link ContextService} by specifying a
+     * {@link ContextServiceDefinition} with the name
+     * <code>java:comp/DefaultContextService</code>.</p>
+     *
+     * @return instructions for capturing and propagating or clearing context.
+     */
+    ContextServiceDefinition context() default @ContextServiceDefinition(name = "java:comp/DefaultContextService");
+
+    /**
+     * <p>The amount of time in milliseconds that a task or action
+     * can execute before it is considered hung.</p>
+     *
+     * <p>The default value of <code>-1</code> indicates unknown.</p>
+     *
+     * @return number of milliseconds after which a task or action
+     *         is considered hung.
+     */
+    long hungTaskThreshold() default -1;
+
+    /**
+     * <p>Upper bound on contextual tasks and actions that this executor
+     * will simultaneously execute asynchronously. This constraint does
+     * not apply to tasks and actions that the executor runs inline,
+     * such as when a thread requests 
+     * {@link java.util.concurrent.CompletableFuture#join()} and the
+     * action runs inline if it has not yet started.</p>
+     *
+     * <p>The default value of <code>-1</code> indicates unbounded,
+     * although still subject to resource constraints of the system.</p>
+     *
+     * @return upper limit on asynchronous execution.
+     */
+    int maxAsync() default -1;
+
+    /**
+     * Enables multiple <code>ManagedExecutorDefinition</code>
+     * annotations on the same type.
+     */
+    @Retention(RUNTIME)
+    @Target(TYPE)
+    public @interface List {
+        ManagedExecutorDefinition[] value();
+    }
+}

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
@@ -52,7 +52,7 @@ import java.lang.annotation.Target;
  * <pre>
  * &lt;resource-env-ref&gt;
  *    &lt;resource-env-ref-name&gt;java:comp/env/concurrent/MyScheduledExecutorRef&lt;/resource-env-ref-name&gt;
- *    &lt;resource-env-ref-type&gt;javax.enterprise.concurrent.ManagedScheduledExecutorService&lt;/resource-env-ref-type&gt;
+ *    &lt;resource-env-ref-type&gt;jakarta.enterprise.concurrent.ManagedScheduledExecutorService&lt;/resource-env-ref-type&gt;
  *    &lt;lookup-name&gt;java:comp/concurrent/MyScheduledExecutor&lt;/lookup-name&gt;
  * &lt;/resource-env-ref&gt;
  * </pre>
@@ -66,7 +66,7 @@ import java.lang.annotation.Target;
 public @interface ManagedScheduledExecutorDefinition {
     /**
      * JNDI name of the {@link ManagedScheduledExecutorService} instance.
-     * The JNDI name must must be in a valid Jakarta EE namespace,
+     * The JNDI name must be in a valid Jakarta EE namespace,
      * such as,
      * <ul>
      * <li>java:comp</li>
@@ -96,7 +96,7 @@ public @interface ManagedScheduledExecutorDefinition {
      * <p>The amount of time in milliseconds that a task or action
      * can execute before it is considered hung.</p>
      *
-     * <p>The default value of <code>-1</code> indicates unknown.</p>
+     * <p>The default value of <code>-1</code> indicates unlimited.</p>
      *
      * @return number of milliseconds after which a task or action
      *         is considered hung.

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.enterprise.concurrent;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * <p>Defines a {@link ManagedScheduledExecutorService}
+ * to be registered in JNDI by the container
+ * under the JNDI name that is specified in the
+ * {@link #name()} attribute.</p>
+ *
+ * <p>Application components can refer to this JNDI name in the
+ * {@link jakarta.annotation.Resource#lookup() lookup} attribute of a
+ * {@link jakarta.annotation.Resource} annotation,</p>
+ *
+ * <pre>{@literal @}ManagedScheduledExecutorDefinition(
+ *     name = "java:comp/concurrent/MyScheduledExecutor",
+ *     hungTaskThreshold = 30000,
+ *     maxAsync = 3,
+ *     context ={@literal @}ContextServiceDefinition(
+ *               name = "java:comp/concurrent/MyScheduledExecutorContext",
+ *               propagated = APPLICATION))
+ * public class MyServlet extends HttpServlet {
+ *    {@literal @}Resource(lookup = "java:comp/concurrent/MyScheduledExecutor",
+ *               name = "java:comp/concurrent/env/MyScheduledExecutorRef")
+ *     ManagedScheduledExecutorService myScheduledExecutor;
+ * </pre>
+ *
+ * <p>Resource environment references in a deployment descriptor
+ * can similarly specify the <code>lookup-name</code>,</p>
+ *
+ * <pre>
+ * &lt;resource-env-ref&gt;
+ *    &lt;resource-env-ref-name&gt;java:comp/env/concurrent/MyScheduledExecutorRef&lt;/resource-env-ref-name&gt;
+ *    &lt;resource-env-ref-type&gt;javax.enterprise.concurrent.ManagedScheduledExecutorService&lt;/resource-env-ref-type&gt;
+ *    &lt;lookup-name&gt;java:comp/concurrent/MyScheduledExecutor&lt;/lookup-name&gt;
+ * &lt;/resource-env-ref&gt;
+ * </pre>
+ *
+ * @since 3.0
+ */
+//TODO could mention relation with <managed-scheduled-executor> definition in deployment descriptor once that is added
+@Repeatable(ManagedScheduledExecutorDefinition.List.class)
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface ManagedScheduledExecutorDefinition {
+    /**
+     * JNDI name of the {@link ManagedScheduledExecutorService} instance.
+     * The JNDI name must must be in a valid Jakarta EE namespace,
+     * such as,
+     * <ul>
+     * <li>java:comp</li>
+     * <li>java:module</li>
+     * <li>java:app</li>
+     * <li>java:global</li>
+     * </ul>
+     *
+     * @return <code>ManagedScheduledExecutorService</code> JNDI name.
+     */
+    String name();
+
+    /**
+     * <p>Determines how context is applied to tasks and actions that
+     * run on this executor.</p>
+     *
+     * <p>The default value indicates to use the default instance of
+     * {@link ContextService} by specifying a
+     * {@link ContextServiceDefinition} with the name
+     * <code>java:comp/DefaultContextService</code>.</p>
+     *
+     * @return instructions for capturing and propagating or clearing context.
+     */
+    ContextServiceDefinition context() default @ContextServiceDefinition(name = "java:comp/DefaultContextService");
+
+    /**
+     * <p>The amount of time in milliseconds that a task or action
+     * can execute before it is considered hung.</p>
+     *
+     * <p>The default value of <code>-1</code> indicates unknown.</p>
+     *
+     * @return number of milliseconds after which a task or action
+     *         is considered hung.
+     */
+    long hungTaskThreshold() default -1;
+
+    /**
+     * <p>Upper bound on contextual tasks and actions that this executor
+     * will simultaneously execute asynchronously. This constraint does
+     * not apply to tasks and actions that the executor runs inline,
+     * such as when a thread requests 
+     * {@link java.util.concurrent.CompletableFuture#join()} and the
+     * action runs inline if it has not yet started.
+     * This constraint also does not apply to tasks that are scheduled
+     * via the <code>schedule*</code> methods.</p>
+     *
+     * <p>The default value of <code>-1</code> indicates unbounded,
+     * although still subject to resource constraints of the system.</p>
+     *
+     * @return upper limit on asynchronous execution.
+     */
+    int maxAsync() default -1;
+
+    /**
+     * Enables multiple <code>ManagedScheduledExecutorDefinition</code>
+     * annotations on the same type.
+     */
+    @Retention(RUNTIME)
+    @Target(TYPE)
+    public @interface List {
+        ManagedScheduledExecutorDefinition[] value();
+    }
+}

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
@@ -51,7 +51,7 @@ import java.lang.annotation.Target;
  * <pre>
  * &lt;resource-env-ref&gt;
  *    &lt;resource-env-ref-name&gt;java:module/env/concurrent/MyThreadFactoryRef&lt;/resource-env-ref-name&gt;
- *    &lt;resource-env-ref-type&gt;javax.enterprise.concurrent.ManagedThreadFactory&lt;/resource-env-ref-type&gt;
+ *    &lt;resource-env-ref-type&gt;jakarta.enterprise.concurrent.ManagedThreadFactory&lt;/resource-env-ref-type&gt;
  *    &lt;lookup-name&gt;java:global/concurrent/MyThreadFactory&lt;/lookup-name&gt;
  * &lt;/resource-env-ref&gt;
  * </pre>
@@ -65,7 +65,7 @@ import java.lang.annotation.Target;
 public @interface ManagedThreadFactoryDefinition {
     /**
      * JNDI name of the {@link ManagedThreadFactory} instance.
-     * The JNDI name must must be in a valid Jakarta EE namespace,
+     * The JNDI name must be in a valid Jakarta EE namespace,
      * such as,
      * <ul>
      * <li>java:comp</li>

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.enterprise.concurrent;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * <p>Defines a {@link ManagedThreadFactory}
+ * to be registered in JNDI by the container
+ * under the JNDI name that is specified in the
+ * {@link #name()} attribute.</p>
+ *
+ * <p>Application components can refer to this JNDI name in the
+ * {@link jakarta.annotation.Resource#lookup() lookup} attribute of a
+ * {@link jakarta.annotation.Resource} annotation,</p>
+ *
+ * <pre>{@literal @}ManagedThreadFactoryDefinition(
+ *     name = "java:global/concurrent/MyThreadFactory",
+ *     priority = "4",
+ *     context ={@literal @}ContextServiceDefinition(
+ *               name = "java:global/concurrent/MyThreadFactoryContext",
+ *               propagated = APPLICATION))
+ * public class MyServlet extends HttpServlet {
+ *    {@literal @}Resource(lookup = "java:global/concurrent/MyThreadFactory",
+ *               name = "java:module/concurrent/env/MyThreadFactoryRef")
+ *     ManagedThreadFactory myThreadFactory;
+ * </pre>
+ *
+ * <p>Resource environment references in a deployment descriptor
+ * can similarly specify the <code>lookup-name</code>,</p>
+ *
+ * <pre>
+ * &lt;resource-env-ref&gt;
+ *    &lt;resource-env-ref-name&gt;java:module/env/concurrent/MyThreadFactoryRef&lt;/resource-env-ref-name&gt;
+ *    &lt;resource-env-ref-type&gt;javax.enterprise.concurrent.ManagedThreadFactory&lt;/resource-env-ref-type&gt;
+ *    &lt;lookup-name&gt;java:global/concurrent/MyThreadFactory&lt;/lookup-name&gt;
+ * &lt;/resource-env-ref&gt;
+ * </pre>
+ *
+ * @since 3.0
+ */
+//TODO could mention relation with <managed-thread-factory> definition in deployment descriptor once that is added
+@Repeatable(ManagedThreadFactoryDefinition.List.class)
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface ManagedThreadFactoryDefinition {
+    /**
+     * JNDI name of the {@link ManagedThreadFactory} instance.
+     * The JNDI name must must be in a valid Jakarta EE namespace,
+     * such as,
+     * <ul>
+     * <li>java:comp</li>
+     * <li>java:module</li>
+     * <li>java:app</li>
+     * <li>java:global</li>
+     * </ul>
+     *
+     * @return <code>ManagedThreadFactory</code> JNDI name.
+     */
+    String name();
+
+    /**
+     * <p>Determines how context is applied to threads from this
+     * thread factory.</p>
+     *
+     * <p>The default value indicates to use the default instance of
+     * {@link ContextService} by specifying a
+     * {@link ContextServiceDefinition} with the name
+     * <code>java:comp/DefaultContextService</code>.</p>
+     *
+     * @return instructions for capturing and propagating or clearing context.
+     */
+    ContextServiceDefinition context() default @ContextServiceDefinition(name = "java:comp/DefaultContextService");
+
+    /**
+     * <p>Priority for threads created by this thread factory.</p>
+     *
+     * <p>The default is {@link java.lang.Thread#NORM_PRIORITY}.</p>
+     *
+     * @return the priority for new threads.
+     */
+    int priority() default Thread.NORM_PRIORITY;
+
+    /**
+     * Enables multiple <code>ManagedThreadFactoryDefinition</code>
+     * annotations on the same type.
+     */
+    @Retention(RUNTIME)
+    @Target(TYPE)
+    public @interface List {
+        ManagedThreadFactoryDefinition[] value();
+    }
+}

--- a/api/src/test/java/jakarta/enterprise/concurrent/ContextServiceDefinitionTest.java
+++ b/api/src/test/java/jakarta/enterprise/concurrent/ContextServiceDefinitionTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.enterprise.concurrent;
+
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.ALL_REMAINING;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.APPLICATION;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.SECURITY;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.TRANSACTION;
+import static org.junit.Assert.*;
+
+import jakarta.annotation.Resource;
+import org.junit.Test;
+
+@ContextServiceDefinition( // from ContextServiceDefinition JavaDoc
+        name = "java:app/concurrent/MyContext",
+        propagated = APPLICATION,
+        unchanged = TRANSACTION,
+        cleared = ALL_REMAINING)
+@ContextServiceDefinition(
+        name = "java:comp/concurrent/ContextServiceDefinitionDefaults")
+@ContextServiceDefinition( // from ALL_REMAINING JavaDoc
+        name = "java:module/concurrent/SecurityContext",
+        propagated = SECURITY,
+        unchanged = TRANSACTION,
+        cleared = ALL_REMAINING)
+public class ContextServiceDefinitionTest {
+
+    // from ContextServiceDefinition JavaDoc
+    @Resource(lookup = "java:app/concurrent/MyContext",
+              name = "java:app/concurrent/env/MyContextRef")
+    ContextService appContextSvc;
+
+    /**
+     * Validate the example that is used in the ALL_REMAINING JavaDoc.
+     */
+    @Test
+    public void testContextServiceDefinitionALL_REMAININGJavaDocExample() throws Exception {
+        ContextServiceDefinition csdSecurityContext = null;
+        for (ContextServiceDefinition anno : ContextServiceDefinitionTest.class.getAnnotationsByType(ContextServiceDefinition.class))
+            if ("java:module/concurrent/SecurityContext".equals(anno.name()))
+                csdSecurityContext = anno;
+        assertNotNull(csdSecurityContext);
+        assertArrayEquals(new String[] { SECURITY }, csdSecurityContext.propagated());
+        assertArrayEquals(new String[] { TRANSACTION }, csdSecurityContext.unchanged());
+        assertArrayEquals(new String[] { ALL_REMAINING }, csdSecurityContext.cleared());
+    }
+
+    /**
+     * Validate the default values for ContextServiceDefinition.
+     */
+    @Test
+    public void testContextServiceDefinitionDefaultValues() throws Exception {
+        ContextServiceDefinition csdDefaults = null;
+        for (ContextServiceDefinition anno : ContextServiceDefinitionTest.class.getAnnotationsByType(ContextServiceDefinition.class))
+            if ("java:comp/concurrent/ContextServiceDefinitionDefaults".equals(anno.name()))
+                csdDefaults = anno;
+        assertNotNull(csdDefaults);
+        assertArrayEquals(new String[] { TRANSACTION }, csdDefaults.cleared());
+        assertArrayEquals(new String[] {}, csdDefaults.unchanged());
+        assertArrayEquals(new String[] { ALL_REMAINING }, csdDefaults.propagated());
+    }
+
+    /**
+     * Validate the example that is used in ContextServiceDefinition JavaDoc.
+     */
+    @Test
+    public void testContextServiceDefinitionJavaDocExample() throws Exception {
+        ContextServiceDefinition csdMyContext = null;
+        for (ContextServiceDefinition anno : ContextServiceDefinitionTest.class.getAnnotationsByType(ContextServiceDefinition.class))
+            if ("java:app/concurrent/MyContext".equals(anno.name()))
+                csdMyContext = anno;
+        assertNotNull(csdMyContext);
+        assertArrayEquals(new String[] { APPLICATION }, csdMyContext.propagated());
+        assertArrayEquals(new String[] { TRANSACTION }, csdMyContext.unchanged());
+        assertArrayEquals(new String[] { ALL_REMAINING }, csdMyContext.cleared());
+    }
+}

--- a/api/src/test/java/jakarta/enterprise/concurrent/ManagedExecutorDefinitionTest.java
+++ b/api/src/test/java/jakarta/enterprise/concurrent/ManagedExecutorDefinitionTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.enterprise.concurrent;
+
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.ALL_REMAINING;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.APPLICATION;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.SECURITY;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.TRANSACTION;
+import static org.junit.Assert.*;
+
+import jakarta.annotation.Resource;
+import org.junit.Test;
+
+@ManagedExecutorDefinition( // from ManagedExecutorDefinition JavaDoc
+        name = "java:module/concurrent/MyExecutor",
+        hungTaskThreshold = 120000,
+        maxAsync = 5,
+        context = @ContextServiceDefinition(
+                  name = "java:module/concurrent/MyExecutorContext",
+                  propagated = { SECURITY, APPLICATION }))
+@ManagedExecutorDefinition(
+        name = "java:app/concurrent/ManagedExecutorDefinitionDefaults")
+public class ManagedExecutorDefinitionTest {
+
+    // from ManagedExecutorDefinition JavaDoc
+    @Resource(lookup = "java:module/concurrent/MyExecutor",
+              name = "java:module/concurrent/env/MyExecutorRef")
+    ManagedExecutorService myExecutor;
+
+    /**
+     * Validate the default values for ManagedExecutorDefinition.
+     */
+    @Test
+    public void testManagedExecutorDefinitionDefaultValues() throws Exception {
+        ManagedExecutorDefinition def = null;
+        for (ManagedExecutorDefinition anno : ManagedExecutorDefinitionTest.class.getAnnotationsByType(ManagedExecutorDefinition.class))
+            if ("java:app/concurrent/ManagedExecutorDefinitionDefaults".equals(anno.name()))
+                def = anno;
+        assertNotNull(def);
+        assertEquals(-1, def.hungTaskThreshold());
+        assertEquals(-1, def.maxAsync());
+        ContextServiceDefinition csd = def.context();
+        assertEquals("java:comp/DefaultContextService", csd.name());
+        assertArrayEquals(new String[] { TRANSACTION }, csd.cleared());
+        assertArrayEquals(new String[] {}, csd.unchanged());
+        assertArrayEquals(new String[] { ALL_REMAINING }, csd.propagated());
+    }
+
+    /**
+     * Validate the example that is used in ManagedExecutorDefinition JavaDoc.
+     */
+    @Test
+    public void testManagedExecutorDefinitionJavaDocExample() throws Exception {
+        ManagedExecutorDefinition def = null;
+        for (ManagedExecutorDefinition anno : ManagedExecutorDefinitionTest.class.getAnnotationsByType(ManagedExecutorDefinition.class))
+            if ("java:module/concurrent/MyExecutor".equals(anno.name()))
+                def = anno;
+        assertNotNull(def);
+        assertEquals(120000, def.hungTaskThreshold());
+        assertEquals(5, def.maxAsync());
+        ContextServiceDefinition csd = def.context();
+        assertEquals("java:module/concurrent/MyExecutorContext", csd.name());
+        assertArrayEquals(new String[] { SECURITY, APPLICATION }, csd.propagated());
+        assertArrayEquals(new String[] { TRANSACTION }, csd.cleared());
+        assertArrayEquals(new String[] {}, csd.unchanged());
+    }
+}

--- a/api/src/test/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinitionTest.java
+++ b/api/src/test/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinitionTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.enterprise.concurrent;
+
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.ALL_REMAINING;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.APPLICATION;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.SECURITY;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.TRANSACTION;
+import static org.junit.Assert.*;
+
+import jakarta.annotation.Resource;
+import org.junit.Test;
+
+@ManagedScheduledExecutorDefinition( // from ManagedScheduledExecutorDefinition JavaDoc
+        name = "java:comp/concurrent/MyScheduledExecutor",
+        hungTaskThreshold = 30000,
+        maxAsync = 3,
+        context = @ContextServiceDefinition(
+                  name = "java:comp/concurrent/MyScheduledExecutorContext",
+                  propagated = APPLICATION))
+@ManagedScheduledExecutorDefinition(
+        name = "java:global/concurrent/ManagedScheduledExecutorDefinitionDefaults")
+public class ManagedScheduledExecutorDefinitionTest {
+
+    // from ManagedScheduledExecutorDefinition JavaDoc
+    @Resource(lookup = "java:comp/concurrent/MyScheduledExecutor",
+              name = "java:comp/concurrent/env/MyScheduledExecutorRef")
+    ManagedScheduledExecutorService myScheduledExecutor;
+
+    /**
+     * Validate the default values for ManagedScheduledExecutorDefinition.
+     */
+    @Test
+    public void testManagedScheduledExecutorDefinitionDefaultValues() throws Exception {
+        ManagedScheduledExecutorDefinition def = null;
+        for (ManagedScheduledExecutorDefinition anno : ManagedScheduledExecutorDefinitionTest.class
+                .getAnnotationsByType(ManagedScheduledExecutorDefinition.class))
+            if ("java:global/concurrent/ManagedScheduledExecutorDefinitionDefaults".equals(anno.name()))
+                def = anno;
+        assertNotNull(def);
+        assertEquals(-1, def.hungTaskThreshold());
+        assertEquals(-1, def.maxAsync());
+        ContextServiceDefinition csd = def.context();
+        assertEquals("java:comp/DefaultContextService", csd.name());
+        assertArrayEquals(new String[] { TRANSACTION }, csd.cleared());
+        assertArrayEquals(new String[] {}, csd.unchanged());
+        assertArrayEquals(new String[] { ALL_REMAINING }, csd.propagated());
+    }
+
+    /**
+     * Validate the example that is used in ManagedScheduledExecutorDefinition JavaDoc.
+     */
+    @Test
+    public void testManagedScheduledExecutorDefinitionJavaDocExample() throws Exception {
+        ManagedScheduledExecutorDefinition def = null;
+        for (ManagedScheduledExecutorDefinition anno : ManagedScheduledExecutorDefinitionTest.class
+                .getAnnotationsByType(ManagedScheduledExecutorDefinition.class))
+            if ("java:comp/concurrent/MyScheduledExecutor".equals(anno.name()))
+                def = anno;
+        assertNotNull(def);
+        assertEquals(30000, def.hungTaskThreshold());
+        assertEquals(3, def.maxAsync());
+        ContextServiceDefinition csd = def.context();
+        assertEquals("java:comp/concurrent/MyScheduledExecutorContext", csd.name());
+        assertArrayEquals(new String[] { APPLICATION }, csd.propagated());
+        assertArrayEquals(new String[] { TRANSACTION }, csd.cleared());
+        assertArrayEquals(new String[] {}, csd.unchanged());
+    }
+}

--- a/api/src/test/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinitionTest.java
+++ b/api/src/test/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinitionTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.enterprise.concurrent;
+
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.ALL_REMAINING;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.APPLICATION;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.SECURITY;
+import static jakarta.enterprise.concurrent.ContextServiceDefinition.TRANSACTION;
+import static org.junit.Assert.*;
+
+import jakarta.annotation.Resource;
+import org.junit.Test;
+
+@ManagedThreadFactoryDefinition( // from ManagedThreadFactoryDefinition JavaDoc
+        name = "java:global/concurrent/MyThreadFactory",
+        priority = 4,
+        context = @ContextServiceDefinition(
+                  name = "java:global/concurrent/MyThreadFactoryContext",
+                  propagated = APPLICATION))
+@ManagedThreadFactoryDefinition(
+        name = "java:comp/concurrent/ManagedThreadFactoryDefinitionDefaults")
+public class ManagedThreadFactoryDefinitionTest {
+
+    // from ManagedThreadFactoryDefinition JavaDoc
+    @Resource(lookup = "java:global/concurrent/MyThreadFactory",
+              name = "java:module/concurrent/env/MyThreadFactoryRef")
+    ManagedThreadFactory myThreadFactory;
+
+    /**
+     * Validate the default values for ManagedThreadFactoryDefinition.
+     */
+    @Test
+    public void testManagedThreadFactoryDefinitionDefaultValues() throws Exception {
+        ManagedThreadFactoryDefinition def = null;
+        for (ManagedThreadFactoryDefinition anno : ManagedThreadFactoryDefinitionTest.class
+                .getAnnotationsByType(ManagedThreadFactoryDefinition.class))
+            if ("java:comp/concurrent/ManagedThreadFactoryDefinitionDefaults".equals(anno.name()))
+                def = anno;
+        assertNotNull(def);
+        assertEquals(Thread.NORM_PRIORITY, def.priority());
+        ContextServiceDefinition csd = def.context();
+        assertEquals("java:comp/DefaultContextService", csd.name());
+        assertArrayEquals(new String[] { TRANSACTION }, csd.cleared());
+        assertArrayEquals(new String[] {}, csd.unchanged());
+        assertArrayEquals(new String[] { ALL_REMAINING }, csd.propagated());
+    }
+
+    /**
+     * Validate the example that is used in ManagedThreadFactoryDefinition JavaDoc.
+     */
+    @Test
+    public void testManagedThreadFactoryDefinitionJavaDocExample() throws Exception {
+        ManagedThreadFactoryDefinition def = null;
+        for (ManagedThreadFactoryDefinition anno : ManagedThreadFactoryDefinitionTest.class
+                .getAnnotationsByType(ManagedThreadFactoryDefinition.class))
+            if ("java:global/concurrent/MyThreadFactory".equals(anno.name()))
+                def = anno;
+        assertNotNull(def);
+        assertEquals(4, def.priority());
+        ContextServiceDefinition csd = def.context();
+        assertEquals("java:global/concurrent/MyThreadFactoryContext", csd.name());
+        assertArrayEquals(new String[] { APPLICATION }, csd.propagated());
+        assertArrayEquals(new String[] { TRANSACTION }, csd.cleared());
+        assertArrayEquals(new String[] {}, csd.unchanged());
+    }
+}


### PR DESCRIPTION
This pull is the first step toward #38
It creates resource definition annotations:

`@ContextServiceDefinition`
`@ManagedExecutorDefinition`
`@ManagedScheduledExecutorDefinition`
`@ManagedThreadFactory`

along with a handful of attributes for each - hopefully the most basic ones that will be common across implementations and therefore non-controversial.  More can certainly be added in follow-on pulls.  I have not marked this pull to close out the issue, so that separate pulls will still be able to further build on top of this, adding in whatever other config is agreed upon.

Actions to accomplish after this pull goes in:

- add more attributes
- create corresponding `<context-service>`, `<managed-executor>`, `<managed-scheduled-executor>`, `<managed-thread-factory>` definitions in deployment descriptor schema
- potentially replace config examples in the specification document with these annotations and/or deployment descriptor elements.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>