### PR TITLE
asynchronous methods annotation

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -332,6 +332,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>4.0.0.Alpha2</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13</version>

--- a/api/src/main/java/jakarta/enterprise/concurrent/Async.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Async.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.enterprise.concurrent;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.CompletableFuture;
+
+import jakarta.enterprise.util.Nonbinding;
+import jakarta.interceptor.InterceptorBinding;
+
+/**
+ * Annotates a CDI managed bean method (or CDI managed bean class containing suitable methods)
+ * to run asynchronously.
+ * <p>
+ * The Jakarta EE Product Provider runs the method on a {@link ManagedExecutorService}
+ * and returns to the caller a {@link java.util.concurrent.CompletableFuture CompletableFuture}
+ * that is backed by the same <code>ManagedExecutorService</code>
+ * to represent the execution of the method. The <code>ManagedExecutorService</code>
+ * is the default asynchronous execution facility for the <code>CompletableFuture</code>
+ * and and all dependent stages that are created from those, and so on,
+ * as defined by the <code>ManagedExecutorService</code> JavaDoc API.
+ * The Jakarta EE Product Provider makes this <code>CompletableFuture</code> available
+ * to the asynchronous method implementation via the
+ * {@link Result#getFuture Async.Result.getFuture} and
+ * {@link Result#complete Async.Result.complete} methods.
+ * <p>
+ * For example,
+ *
+ * <pre>
+ * {@literal @}Async
+ * public CompletableFuture{@literal <Double>} hoursWorked(LocalDate from, LocalDate to) {
+ *     // Application component's context is made available to the async method,
+ *     try (Connection con = ((DataSource) InitialContext.doLookup(
+ *         "java:comp/env/jdbc/timesheetDB")).getConnection()) {
+ *         ...
+ *         return Async.Result.complete(total);
+ *     } catch (NamingException | SQLException x) {
+ *         throw new CompletionException(x);
+ *     }
+ * }
+ * </pre>
+ *
+ * with usage,
+ *
+ * <pre>
+ * hoursWorked(mon, fri).thenAccept(total {@literal ->} {
+ *     // Application component's context is made available to dependent stage actions,
+ *     DataSource ds = InitialContext.doLookup(
+ *         "java:comp/env/jdbc/payrollDB");
+ *     ...
+ * });
+ * </pre>
+ *
+ * When the asynchronous method implementation returns a different
+ * <code>CompletableFuture</code> instance, the Jakarta EE Product Provider
+ * uses the completion of that instance to complete the <code>CompletableFuture</code>
+ * that the Jakarta EE Product Provider returns to the caller,
+ * completing it with the same result or exception.
+ * <p>
+ * For example,
+ *
+ * <pre>
+ * {@literal @}Async
+ * public CompletableFuture{@literal <List<Itinerary>>} findSingleLayoverFlights(Location source, Location dest) {
+ *     try {
+ *         ManagedExecutorService executor = InitialContext.doLookup(
+ *             "java:comp/DefaultManagedExecutorService");
+ *
+ *         return executor.supplyAsync(source::flightsFrom)
+ *                        .thenCombine(executor.completedFuture(dest.flightsTo()),
+ *                                     Itinerary::sourceMatchingDest);
+ *     } catch (NamingException x) {
+ *         throw new CompletionException(x);
+ *     }
+ * }
+ * </pre>
+ *
+ * with usage,
+ *
+ * <pre>
+ * findSingleLayoverFlights(RST, DEN).thenApply(Itinerary::sortByPrice);
+ * </pre>
+ *
+ * <p>
+ * When annotating asynchronous methods at the method level, methods
+ * can have any of the following return types, with all other return types resulting in
+ * {@link java.lang.UnsupportedOperationException UnsupportedOperationException}:
+ * <ul>
+ * <li>{@link java.util.concurrent.CompletableFuture CompletableFuture}</li>
+ * <li>{@link java.util.concurrent.CompletionStage CompletionStage}</li>
+ * <li><code>void</code></li>
+ * </ul>
+ * <p>
+ * When annotating asynchronous methods at the class level, methods with
+ * any of the following return types are considered asynchronous methods,
+ * whereas methods with other return types are treated as normal
+ * (non-asynchronous) methods:
+ * <ul>
+ * <li>{@link java.util.concurrent.CompletableFuture CompletableFuture}</li>
+ * <li>{@link java.util.concurrent.CompletionStage CompletionStage}</li>
+ * </ul>
+ * <p>
+ * If the <code>Async</code> annotation is present at both the method and class
+ * level, the annotation that is specified at the method level takes precedence.
+ * <p>
+ * Exceptions that are raised by asynchronous methods are not raised directly
+ * to the caller because the method runs asynchronously to the caller.
+ * Instead, the <code>CompletableFuture</code> that represents the result
+ * is completed with the raised exception. Asynchronous methods are
+ * discouraged from raising checked exceptions because checked exceptions
+ * force the caller to write exception handling code that is unreachable.
+ * When a checked exception occurs, the asynchronous method implementation
+ * can flow the exception back to the resulting <code>CompletableFuture</code>
+ * either by raising a
+ * {@link java.util.concurrent.CompletionException CompletionException}
+ * with the original exception as the cause, or it can take the equivalent
+ * approach of exceptionally completing the <code>CompletableFuture</code>, using
+ * {@link java.util.concurrent.CompletableFuture#completeExceptionally completeExceptionally}
+ * to supply the original exception as the cause.
+ * <p>
+ * Except where otherwise stated, the Jakarta EE Product Provider raises
+ * {@link java.util.concurrent.RejectedExecutionException RejectedExecutionException}
+ * upon invocation of the asynchronous method if evident upfront that it cannot
+ * be accepted, for example if the JNDI name is not valid or points to something
+ * other than a managed executor resource. If determined at a later point that the
+ * asynchronous method cannot run (for example, if unable to establish thread context),
+ * then the Jakarta EE Product Provider completes the <code>CompletableFuture</code>
+ * exceptionally with {@link java.util.concurrent.CancellationException CancellationException},
+ * and chains a cause exception if there is any.
+ * <p>
+ * The Jakarta EE Product Provider must assign the interceptor for asynchronous methods
+ * to have priority of <code>Interceptor.Priority.PLATFORM_BEFORE + 5</code>.
+ * Interceptors with a lower priority, such as <code>Transactional</code>, must run on
+ * the thread where the asynchronous method executes, rather than on the submitting thread.
+ * When an asynchronous method is annotated as <code>Transactional</code>,
+ * the transactional types <code>TxType.REQUIRES_NEW</code> and
+ * <code>TxType.NOT_SUPPORTED</code> can be used. All other transaction attributes must
+ * result in {@link java.lang.UnsupportedOperationException UnsupportedOperationException}
+ * upon invocation of the asynchronous method.
+ *
+ * @since 3.0
+ */
+// TODO the above restrictions on Transactional interceptors could be eliminated
+// if transaction context propagation is later added to the spec.
+@Documented
+@Inherited
+@InterceptorBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
+public @interface Async {
+    /**
+     * JNDI name of a {@link ManagedExecutorService} or {@link ManagedScheduledExecutorService}
+     * upon which to run the asynchronous method.
+     * <p>
+     * The default value is the JNDI name of the built-in <code>ManagedExecutorService</code>
+     * that is provided by the Jakarta EE platform provider:<br>
+     * <code>java:comp/DefaultManagedExecutorService</code>
+     *
+     * @return managed executor service JNDI name.
+     */
+    @Nonbinding
+    String executor() default "java:comp/DefaultManagedExecutorService";
+
+    /**
+     * Mechanism by which the Jakarta EE Product Provider makes available
+     * to the asynchronous method implementation the same
+     * {@link java.util.concurrent.CompletableFuture CompletableFuture}
+     * instance that the Jakarta EE Product Provider supplies to the caller
+     * of the asynchronous method.
+     * <p>
+     * Before invoking the asynchronous method implementation on a thread,
+     * the Jakarta EE Product Provider invokes the {@link #setFuture} method
+     * which makes available to the asynchronous method implementation
+     * the same <code>CompletableFuture</code> that the Jakarta EE Product Provider
+     * returns to the caller.
+     * <p>
+     * The asynchronous method implementation invokes the {@link #getFuture} method
+     * to obtain the same <code>CompletableFuture</code> that the
+     * Jakarta EE Product Provider returns to the caller.
+     * The asynchronous method implementation can choose to complete
+     * this future (normally or exceptionally) or otherwise arrange for its
+     * completion, for example upon completion of a pipeline of completion stages.
+     * Having this same <code>CompletableFuture</code> also enables the asynchronous
+     * method implementation to determine if the caller has forcibly completed
+     * (such as by cancellation or any other means) the <code>CompletableFuture</code>,
+     * in which case the asynchronous method implementation could decide to end
+     * immediately rather than continue processing.
+     * <p>
+     * For example,
+     *
+     * <pre>
+     * {@literal @}Async
+     * public CompletableFuture{@literal <Double>} hoursWorked(LocalDateTime from, LocalDateTime to) {
+     *     CompletableFuture{@literal <Double>} future = Async.Result.getFuture();
+     *     if (future.isDone())
+     *         return future;
+     *
+     *     try (Connection con = ((DataSource) InitialContext.doLookup(
+     *         "java:comp/env/jdbc/timesheetDB")).getConnection()) {
+     *         ...
+     *         for (ResultSet result = stmt.executeQuery(); result.next() {@literal &&} !future.isDone(); )
+     *             ...
+     *         future.complete(total);
+     *     } catch (NamingException | SQLException x) {
+     *         future.completeExceptionally(x);
+     *     }
+     *     return future;
+     * }
+     * </pre>
+     *
+     * After the asynchronous method completes, the Jakarta EE Product Provider
+     * invokes the {@link #setFuture} method with a <code>null</code> value
+     * to clear it from the thread.
+     *
+     * @since 3.0
+     */
+    public static class Result {
+        private static final ThreadLocal<CompletableFuture<?>> futures = new ThreadLocal<CompletableFuture<?>>();
+
+        /**
+         * Completes the {@link java.util.concurrent.CompletableFuture CompletableFuture}
+         * instance that the Jakarta EE Product Provider supplies to the caller of the
+         * asynchronous method.
+         * <p>
+         * This method must only be invoked by the asynchronous method implementation.
+         *
+         * @param <T>    type of result returned by the asynchronous method's <code>CompletableFuture</code>.
+         * @param result result with which to complete the asynchronous method's <code>CompletableFuture</code>.
+         * @return the same <code>CompletableFuture</code> that the container returns to the caller.
+         * @throws IllegalStateException if the <code>CompletableFuture</code> for an asynchronous
+         *                                   method is not present on the thread.
+         */
+        public static <T> CompletableFuture<T> complete(T result) {
+            @SuppressWarnings("unchecked")
+            CompletableFuture<T> future = (CompletableFuture<T>) futures.get();
+            if (future == null)
+                throw new IllegalStateException();
+            future.complete(result);
+            return future;
+        }
+
+        /**
+         * Obtains the same {@link java.util.concurrent.CompletableFuture CompletableFuture}
+         * instance that the Jakarta EE Product Provider supplies to the caller of the
+         * asynchronous method.
+         * <p>
+         * This method must only be invoked by the asynchronous method implementation.
+         *
+         * @param <T>  type of result returned by the asynchronous method's <code>CompletableFuture</code>.
+         * @return the same <code>CompletableFuture</code> that the container returns to the caller.
+         * @throws IllegalStateException if the <code>CompletableFuture</code> for an asynchronous
+         *                                   method is not present on the thread.
+         */
+        public static <T> CompletableFuture<T> getFuture() {
+            @SuppressWarnings("unchecked")
+            CompletableFuture<T> future = (CompletableFuture<T>) futures.get();
+            if (future == null)
+                throw new IllegalStateException();
+            return future;
+        }
+
+        /**
+         * Before invoking the asynchronous method implementation on a thread,
+         * the Jakarta EE Product Provider invokes this method to make available
+         * to the asynchronous method implementation the same <code>CompletableFuture</code>
+         * that the Jakarta EE Product Provider returns to the caller.
+         * <p>
+         * After the asynchronous method completes, the Jakarta EE Product Provider
+         * invokes this method with a <code>null</code> value
+         * to clear it from the thread.
+         * <p>
+         * This method must only be invoked by the Jakarta EE Product Provider.
+         *
+         * @param <T>    type of result returned by the asynchronous method's <code>CompletableFuture</code>.
+         * @param future <code>CompletableFuture</code> that the container returns to the caller,
+         *               or <code>null</code> to clear it.
+         */
+        public static <T> void setFuture(CompletableFuture<T> future) {
+            if (future == null)
+                futures.remove();
+            else
+                futures.set(future);
+        }
+    }
+}

--- a/api/src/test/java/jakarta/enterprise/concurrent/AsyncTest.java
+++ b/api/src/test/java/jakarta/enterprise/concurrent/AsyncTest.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.enterprise.concurrent;
+
+import static org.junit.Assert.*;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+
+import org.junit.Test;
+
+/**
+ * This test includes the code examples from the specification and JavaDoc
+ * for asychronous methods, verifying that they compile.
+ * The Async.Result class is also tested.
+ */
+@Async(executor = "java:module/env/concurrent/class-level-async-executor")
+public class AsyncTest {
+    /**
+     * Example from the section on Asynchronous Methods in the Concurrency spec.
+     */
+    @Async(executor = "java:module/env/concurrent/myExecutorRef")
+    public CompletableFuture<Set<Item>> findSimilar(Cart cart, History h) {
+        Set<Item> combined = new LinkedHashSet<Item>();
+        for (Item item : cart.items())
+            combined.addAll(item.similar());
+        for (Item item : h.recentlyViewed(3))
+            combined.addAll(item.similar());
+        combined.removeAll(cart.items());
+
+        try (Connection con = ((DataSource) InitialContext.doLookup(
+                              "java:comp/env/jdbc/ds1")).getConnection()) {
+            PreparedStatement stmt = con.prepareStatement("...");
+            for (Item item : combined) {
+                // ... Remove if the similar item is unavailable
+            }
+        } catch (NamingException | SQLException x) {
+            throw new CompletionException(x);
+        }
+        return Async.Result.complete(combined);
+    }
+
+    /**
+     * Second example from the Async class JavaDoc.
+     */
+    @Async
+    public CompletableFuture<List<Itinerary>> findSingleLayoverFlights(Location source, Location dest) {
+        try {
+            ManagedExecutorService executor = InitialContext.doLookup(
+                "java:comp/DefaultManagedExecutorService");
+
+            return executor.supplyAsync(source::flightsFrom)
+                           .thenCombine(executor.completedFuture(dest.flightsTo()),
+                                        Itinerary::destMatchingSource);
+        } catch (NamingException x) {
+            throw new CompletionException(x);
+        }
+    }
+
+    /**
+     * First example from the Async class JavaDoc.
+     */
+    @Async
+    public CompletableFuture<Double> hoursWorked(LocalDate from, LocalDate to) {
+        // Application component's context is made available to the async method,
+        try (Connection con = ((DataSource) InitialContext.doLookup(
+            "java:comp/env/jdbc/timesheetDB")).getConnection()) {
+            // ...
+            double total = 40.0; // added to make the example compile
+            return Async.Result.complete(total);
+        } catch (NamingException | SQLException x) {
+            throw new CompletionException(x);
+        }
+    }
+
+    /**
+     * Example from the Async.Result class JavaDoc.
+     */
+    @Async
+    public CompletableFuture<Double> hoursWorked(LocalDateTime from, LocalDateTime to) {
+        CompletableFuture<Double> future = Async.Result.getFuture();
+        if (future.isDone())
+            return future;
+
+        try (Connection con = ((DataSource) InitialContext.doLookup(
+            "java:comp/env/jdbc/timesheetDB")).getConnection()) {
+            PreparedStatement stmt = con.prepareStatement("SQL"); // added to make the example compile
+            // ...
+            for (ResultSet result = stmt.executeQuery(); result.next() && !future.isDone(); )
+                ; // ...
+            double total = 40.0; // added to make the example compile
+            future.complete(total);
+        } catch (NamingException | SQLException x) {
+            future.completeExceptionally(x);
+        }
+        return future;
+    }
+
+    /**
+     * Used by Concurrency spec example code under Asynchronous Methods section.
+     * This code doesn't do anything; we only need the method signatures to verify compilation of the example.
+     */
+    static class Cart {
+        public List<Item> items() {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Used by Concurrency spec example code under Asynchronous Methods section.
+     * This code doesn't do anything; we only need the method signatures to verify compilation of the example.
+     */
+    static class Customer {
+        public Cart getCart() {
+            return new Cart();
+        }
+
+        public History getHistory() {
+            return new History();
+        }
+    }
+
+    /**
+     * Used by Concurrency spec example code under Asynchronous Methods section.
+     * This code doesn't do anything; we only need the method signatures to verify compilation of the example.
+     */
+    static class History {
+        public Set<Item> recentlyViewed(int max) {
+            return Collections.emptySet();
+        }
+    }
+
+    /**
+     * Used by Concurrency spec example code under Asynchronous Methods section.
+     * This code doesn't do anything; we only need the method signatures to verify compilation of the example.
+     */
+    static class Item {
+        public Set<Item> similar() {
+            return Collections.emptySet();
+        }
+    }
+
+    /**
+     * Used by example from Async class JavaDoc.
+     * This code doesn't do anything; we only need the method signatures to verify compilation of the example.
+     */
+    static class Itinerary {
+        static List<Itinerary> destMatchingSource(List<Itinerary> toDest, List<Itinerary> fromSource) {
+            return Collections.emptyList();
+        }
+        static List<Itinerary> sortByPrice(List<Itinerary> list) {
+            return list;
+        }
+    }
+
+    /**
+     * Used by example from Async class JavaDoc.
+     * This code doesn't do anything; we only need the method signatures to verify compilation of the example.
+     */
+    static class Location {
+        List<Itinerary> flightsFrom() {
+            return Collections.emptyList();
+        }
+        List<Itinerary> flightsTo() {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Verify that the Async annotation can be configured at class level
+     * and that its executor field is populated with the specified value.
+     */
+    @Test
+    public void testAsyncClassLevelAnnotation() throws Exception {
+        Async anno = AsyncTest.class.getAnnotation(Async.class);
+        assertNotNull(anno);
+        assertEquals("java:module/env/concurrent/class-level-async-executor", anno.executor());
+    }
+
+    /**
+     * Verify that the first usage example in the Async class JavaDoc compiles.
+     */
+    @Test
+    public void testAsyncJavaDocUsageExample1() {
+        LocalDateTime mon = LocalDateTime.of(2021, 9, 13, 0, 0, 0);
+        LocalDateTime fri = LocalDateTime.of(2021, 9, 17, 23, 59, 59);
+
+        // Normally, the Jakarta EE Product Provider would do this on the same
+        // thread where the asynchronous method executes, just before it starts.
+        CompletableFuture<Double> future = new CompletableFuture<Double>();
+        Async.Result.setFuture(future);
+
+        // There is no interceptor when running these tests, so this won't actually run async.
+        try {
+            hoursWorked(mon, fri).thenAccept(total -> {
+                try {
+                    DataSource ds = InitialContext.doLookup(
+                        "java:comp/env/jdbc/payrollDB");
+                    // ...
+                } catch (NamingException x) {
+                    throw new CompletionException(x);
+                }
+            });
+        } finally {
+            // Normally, the Jakarta EE Product Provider would do this on the same
+            // thread where the asynchronous method executes, just after it ends.
+            Async.Result.setFuture(null);
+        }
+
+        // Naming lookup will have failed,
+        assertTrue(future.isCompletedExceptionally());
+    }
+
+    /**
+     * Verify that the second usage example in the Async class JavaDoc compiles.
+     */
+    @Test
+    public void testAsyncJavaDocUsageExample2() {
+        Location RST = new Location();
+        Location DEN = new Location();
+
+        try {
+            CompletableFuture<List<Itinerary>> leastToMostExpensive =
+                findSingleLayoverFlights(RST, DEN).thenApply(Itinerary::sortByPrice);
+        } catch (CompletionException x) {
+            // Expected in these tests because this is no interceptor to run the async method on another thread
+        }
+    }
+
+    /**
+     * Verify that the Async annotation can be configured at method level
+     * and that its executor field defaults to the JNDI name of the
+     * built-in ManagedExecutorService that is provided by the Jakarta EE platform.
+     */
+    @Test
+    public void testAsyncMethodLevelAnnotation() throws Exception {
+        Async anno = AsyncTest.class.getMethod("hoursWorked", LocalDate.class, LocalDate.class)
+                                    .getAnnotation(Async.class);
+        assertNotNull(anno);
+        assertEquals("java:comp/DefaultManagedExecutorService", anno.executor());
+    }
+
+    /**
+     * Invoke all of the static methods of Async.Result.
+     */
+    @Test
+    public void testAsyncResult() {
+        try {
+            fail("Must not be present by default: " + Async.Result.getFuture());
+        } catch (IllegalStateException x) {
+            // Pass - detected that this was not invoked from an async method
+        }
+
+        CompletableFuture<String> stringFuture = new CompletableFuture<String>();
+        Async.Result.setFuture(stringFuture);
+        assertEquals(stringFuture, Async.Result.getFuture());
+        Async.Result.setFuture(null);
+        try {
+            fail("Must not be present after removing: " + Async.Result.getFuture());
+        } catch (IllegalStateException x) {
+            // Pass - detected that this was not invoked from an async method
+        }
+
+        CompletableFuture<Integer> intFuture = new CompletableFuture<Integer>();
+        Async.Result.setFuture(intFuture);
+        assertEquals(intFuture, Async.Result.complete(100));
+        Async.Result.setFuture(null);
+        try {
+            fail("Must not be present after removing: " + Async.Result.getFuture());
+        } catch (IllegalStateException x) {
+            // Pass - detected that this was not invoked from an async method
+        }
+
+        CompletableFuture<Boolean> booleanFuture = new CompletableFuture<Boolean>();
+        Async.Result.setFuture(booleanFuture);
+        assertEquals(booleanFuture, Async.Result.getFuture());
+        assertEquals(booleanFuture, Async.Result.complete(true));
+        Async.Result.setFuture(null);
+        try {
+            fail("Must not be present after removing: " + Async.Result.getFuture());
+        } catch (IllegalStateException x) {
+            // Pass - detected that this was not invoked from an async method
+        }
+
+        CompletableFuture<Void> unusedFuture = new CompletableFuture<Void>();
+        Async.Result.setFuture(unusedFuture);
+        Async.Result.setFuture(null);
+        try {
+            fail("Must not be present after removing: " + Async.Result.getFuture());
+        } catch (IllegalStateException x) {
+            // Pass - detected that this was not invoked from an async method
+        }
+    }
+
+    /**
+     * Verify that the usage example in the Asynchronous Methods section of the
+     * Concurrency spec compiles.
+     */
+    @Test
+    public void testAsyncUsageExampleFromSpec() throws Exception {
+        Customer cust = new Customer();
+
+        try {
+            findSimilar(cust.getCart(), cust.getHistory())
+                .thenAccept(recommended -> {
+                    // ... Update page with recommendations
+                }).join();
+        } catch (CompletionException x) {
+            // Naming lookup will have failed because this doesn't run in a real server.
+        }
+    }
+}

--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -2302,3 +2302,159 @@ ends.
 
 See section 3.1.8.2.1 for an example of using a `UserTransaction` within a
 task.
+
+== Asynchronous Methods
+
+The `jakarta.enterprise.concurrent.Async` annotation annotates a
+CDI managed bean method to run asynchronously or annotates a
+CDI managed bean class with methods to run asynchronously.
+
+Each asynchronous method execution corresponds to a managed
+`java.util.concurrent.CompletableFuture` instance that is backed by a
+`jakarta.enterprise.concurrent.ManagedExecutorService` as its default
+asynchronous execution facility. Its dependent stages
+(and all dependent stages that are created from those, and so on)
+continue to be backed by the managed executor service,
+which also manages the propagation of context to completion stage actions.
+Application code, including from within the asynchronous method, can query
+the status of the completable future instance and can choose to complete
+it at any time and by any means.
+
+==== Application Component Provider’s Responsibilities
+
+Application Component Providers (application developers) (EE2.11.2)
+specify the `jakarta.enterprise.concurrent.Async` annotation on
+CDI managed bean methods with return type of
+`java.util.concurrent.CompletableFuture`,
+`java.util.concurrent.CompletionStage`, or `void` to designate them for
+asynchronous execution. Alternatively, the
+`jakarta.enterprise.concurrent.Async` annotation can be specified on a
+CDI managed bean class to designate all methods with return type of
+`java.util.concurrent.CompletableFuture` or
+`java.util.concurrent.CompletionStage` for asynchronous execution.
+
+The Application Component Provider supplies the implementation of the
+asynchronous method. If the method has return type of
+`java.util.concurrent.CompletableFuture` or
+`java.util.concurrent.CompletionStage`, its implementation arranges for the
+completion of a completable future or completion stage, which it returns
+as the method result. The asynchronous method can create or obtain a new
+completion stage for this purpose, or it can use the
+`jakarta.enterprise.concurrent.Async.Result` API to obtain the same
+instance that is being returned to the caller of the asynchronous method.
+
+===== Usage Example
+
+In this example, an application component wants to asynchronously identify
+similar items that a customer might wish to purchase.
+
+====== Asynchronous Method Definition
+
+To check if the recommended similar items are currently available for
+purchase, this asynchronous method relies on an external database that
+is accessible via a resource reference that is defined in the application
+component's java:comp namespace, which must be made available to the
+asynchronous method.
+
+[source,java]
+----
+public class ProductRecommendations {
+   @Async(executor = "java:module/env/concurrent/myExecutorRef")
+   public CompletableFuture<Set<Item>> findSimilar(Cart cart, History h) {
+      Set<Item> combined = new LinkedHashSet<Item>();
+      for (Item item : cart.items())
+         combined.addAll(item.similar());
+      for (Item item : h.recentlyViewed(3))
+         combined.addAll(item.similar());
+      combined.removeAll(cart.items());
+
+      try (Connection con = ((DataSource) InitialContext.doLookup(
+                            "java:comp/env/jdbc/ds1")).getConnection()) {
+         PreparedStatement stmt = con.prepareStatement(CHECK_AVAILABILITY);
+         for (Item item : combined) {
+            ... Remove if the similar item is unavailable
+         }
+      } catch (NamingException | SQLException x) {
+         throw new CompletionException(x);
+      }
+      return Async.Result.complete(combined);
+   }
+}
+----
+====== Asynchronous Method Invocation
+
+The CDI managed bean with the asynchronous method is injected into a
+a `Servlet`, which uses it to asynchronously determine the product
+recommendations.
+
+[source,java]
+----
+public class CheckoutServlet extends HttpServlet {
+   @Inject
+   ProductRecommendations recommendations;
+
+   @Resource(name=”java:comp/env/jdbc/ds1”, lookup="jdbc/ds1")
+   DataSource ds;
+
+   public void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException {
+      ...
+      recommendations.findSimilar(cust.getCart(), cust.getHistory())
+                     .thenAccept(recommended -> {
+                        ... Update page with recommendations
+                     });
+      ...
+   }
+}
+----
+
+==== Jakarta EE Product Provider’s Responsibilities
+
+The Jakarta EE Product Provider’s responsibilities are as defined in
+EE.5.8.3.
+
+The Jakarta EE Product Provider registers a CDI interceptor
+to arrange for the invocation of asynchronous methods on the
+`jakarta.enterprise.concurrent.ManagedExecutorService` or
+`jakarta.enterprise.concurrent.ManagedScheduledExecutorService`
+that is specified by the `jakarta.enterprise.concurrent.Async`
+annotation.
+
+The Jakarta EE Product Provider creates a
+`java.util.concurrent.CompletableFuture` instance to associate with each
+asynchronous method invocation, returning this same instance to the caller
+of the asynchronous method, and providing it to the asynchronous method
+implementation by means of the
+`jakarta.enterprise.concurrent.Async.Result` API. The Jakarta EE Product
+Provider completes this instance upon completion of the completion stage
+that is returned by the asynchronous method implementation, which is a
+no-op when the asynchronous method implementation chooses to return the
+same instance. If the asynchronous method return type is `void` or if the
+asynchronous method implementation raises an error or exception, the
+Jakarta EE Product Provider completes this instance upon return from the
+asynchronous method implementation. The Jakarta EE Product Provider
+raises `java.util.concurrent.RejectedExecutionException` to the caller of
+the asynchronous method if it cannot accept a method for asynchronous
+execution, for example if supplied with an invalid JNDI name.
+If the Jakarta EE Product Provider cannot start the asynchronous method
+for any reason after this point, it completes the
+`java.util.concurrent.CompletableFuture` instance with a
+`java.util.concurrent.CancellationException`.
+
+==== Transaction Management
+
+Asynchronous method can be annotated with
+`jakarta.transaction.Transactional` types of
+`jakarta.transaction.Transactional.TxType.REQUIRES_NEW` or
+`jakarta.transaction.Transactional.TxType.NOT_SUPPORTED`.
+
+When an asynchronous method is not annotated as
+`jakarta.transaction.Transactional` or the transaction type is set to
+`TxType.NOT_SUPPORTED`, the Jakarta EE Product Provider
+must support user-managed global transaction demarcation using the
+`jakarta.transaction.UserTransaction` interface, which is described in the
+Jakarta Transactions specification. User-managed transactions allow
+components to manually control global transaction demarcation
+boundaries. Task implementations may optionally begin, commit, and
+roll-back a transaction. See EE.4 for details on transaction management
+in Jakarta EE.


### PR DESCRIPTION
Proposal for #43 asynchronous methods annotation.  This ties into the new support for managed CompletableFuture/CompletionStage instances which includes being able to run all dependent stage actions (including the asynchronous method) with the requesting thread context.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>