### PR TITLE
Update to 3.0 SNAPSHOT and ensure @since 3.0 tags are added

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>jakarta.enterprise.concurrent</groupId>
     <artifactId>jakarta.enterprise.concurrent-api</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <name>jakarta.enterprise.concurrent-api</name>
     <description>Jakarta Concurrency</description>
     <url>https://github.com/eclipse-ee4j/concurrency-api</url>
@@ -64,11 +64,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <api_package>jakarta.enterprise.concurrent</api_package>
-        <non.final>false</non.final>
+        <non.final>true</non.final>
         <last.spec_version>1.1</last.spec_version>
         <next.spec_version>2.0</next.spec_version>
         <spec.version>${next.spec_version}</spec.version>
-        <new.spec.version />
+        <new.spec.version>3.0</new.spec.version>
         <build_number />
         <packages.export>jakarta.enterprise.concurrent.*; version=${spec.bundle.version}</packages.export>
     </properties>
@@ -151,7 +151,7 @@
                 <configuration>
                     <spec>
                         <specVersion>${spec.version}</specVersion>
-                        <specImplVersion>2.0.0</specImplVersion>
+                        <specImplVersion>3.0.0</specImplVersion>
                         <apiPackage>${api_package}</apiPackage>
                         
                         <nonFinal>${non.final}</nonFinal>

--- a/api/src/main/java/jakarta/enterprise/concurrent/ContextService.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ContextService.java
@@ -99,6 +99,7 @@ public interface ContextService {
    * @param callable instance to contextualize.
    * @return contextualized proxy instance that wraps execution of the <code>call</code> method with context.
    * @throws IllegalArgumentException if an already-contextualized <code>Callable</code> is supplied to this method.
+   * @since 3.0
    */
   public <R> Callable<R> contextualCallable(Callable<R> callable);
 
@@ -117,6 +118,7 @@ public interface ContextService {
    * @param consumer instance to contextualize.
    * @return contextualized proxy instance that wraps execution of the <code>accept</code> method with context.
    * @throws IllegalArgumentException if an already-contextualized <code>BiConsumer</code> is supplied to this method.
+   * @since 3.0
    */
   public <T, U> BiConsumer<T, U> contextualConsumer(BiConsumer<T, U> consumer);
 
@@ -134,6 +136,7 @@ public interface ContextService {
    * @param consumer instance to contextualize.
    * @return contextualized proxy instance that wraps execution of the <code>accept</code> method with context.
    * @throws IllegalArgumentException if an already-contextualized <code>Consumer</code> is supplied to this method.
+   * @since 3.0
    */
   public <T> Consumer<T> contextualConsumer(Consumer<T> consumer);
 
@@ -154,6 +157,7 @@ public interface ContextService {
    * @param function instance to contextualize.
    * @return contextualized proxy instance that wraps execution of the <code>apply</code> method with context.
    * @throws IllegalArgumentException if an already-contextualized <code>BiFunction</code> is supplied to this method.
+   * @since 3.0
    */
   public <T, U, R> BiFunction<T, U, R> contextualFunction(BiFunction<T, U, R> function);
 
@@ -173,6 +177,7 @@ public interface ContextService {
    * @param function instance to contextualize.
    * @return contextualized proxy instance that wraps execution of the <code>apply</code> method with context.
    * @throws IllegalArgumentException if an already-contextualized <code>Function</code> is supplied to this method.
+   * @since 3.0
    */
   public <T, R> Function<T, R> contextualFunction(Function<T, R> function);
 
@@ -189,6 +194,7 @@ public interface ContextService {
    * @param runnable instance to contextualize.
    * @return contextualized proxy instance that wraps execution of the <code>run</code> method with context.
    * @throws IllegalArgumentException if an already-contextualized <code>Runnable</code> is supplied to this method.
+   * @since 3.0
    */
   public Runnable contextualRunnable(Runnable runnable);
 
@@ -206,6 +212,7 @@ public interface ContextService {
    * @param supplier instance to contextualize.
    * @return contextualized proxy instance that wraps execution of the <code>supply</code> method with context.
    * @throws IllegalArgumentException if an already-contextualized <code>Supplier</code> is supplied to this method.
+   * @since 3.0
    */
   public <R> Supplier<R> contextualSupplier(Supplier<R> supplier);
 
@@ -446,6 +453,7 @@ public interface ContextService {
    * <code>execute</code> method.</p>
    *
    * @return an executor that wraps the <code>execute</code> method with context.
+   * @since 3.0
    */
   public Executor currentContextExecutor();
 
@@ -484,6 +492,7 @@ public interface ContextService {
    * @param stage a completable future whose completion triggers completion of the new completable
    *        future that is created by this method.
    * @return the new completable future.
+   * @since 3.0
    */
   public <T> CompletableFuture<T> withContextCapture(CompletableFuture<T> stage);
 
@@ -509,6 +518,7 @@ public interface ContextService {
    * @param stage a completion stage whose completion triggers completion of the new stage
    *        that is created by this method.
    * @return the new completion stage.
+   * @since 3.0
    */
   public <T> CompletionStage<T> withContextCapture(CompletionStage<T> stage);
 }

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorService.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorService.java
@@ -237,6 +237,7 @@ public interface ManagedExecutorService extends ExecutorService {
      * @param value result with which the completable future is completed.
      * @param <U> result type of the completable future.
      * @return the new completable future.
+     * @since 3.0
      */
     <U> CompletableFuture<U> completedFuture(U value);
 
@@ -251,6 +252,7 @@ public interface ManagedExecutorService extends ExecutorService {
      * @param value result with which the completion stage is completed.
      * @param <U> result type of the completion stage.
      * @return the new completion stage.
+     * @since 3.0
      */
     <U> CompletionStage<U> completedStage(U value);
 
@@ -283,6 +285,7 @@ public interface ManagedExecutorService extends ExecutorService {
      * @param stage a completable future whose completion triggers completion of the new completable
      *        future that is created by this method.
      * @return the new completable future.
+     * @since 3.0
      */
     <T> CompletableFuture<T> copy(CompletableFuture<T> stage);
 
@@ -315,6 +318,7 @@ public interface ManagedExecutorService extends ExecutorService {
      * @param stage a completion stage whose completion triggers completion of the new stage
      *        that is created by this method.
      * @return the new completion stage.
+     * @since 3.0
      */
     <T> CompletionStage<T> copy(CompletionStage<T> stage);
 
@@ -329,6 +333,7 @@ public interface ManagedExecutorService extends ExecutorService {
      * @param ex exception or error with which the completable future is completed.
      * @param <U> result type of the completable future.
      * @return the new completable future.
+     * @since 3.0
      */
     <U> CompletableFuture<U> failedFuture(Throwable ex);
 
@@ -343,6 +348,7 @@ public interface ManagedExecutorService extends ExecutorService {
      * @param ex exception or error with which the completion stage is completed.
      * @param <U> result type of the completion stage.
      * @return the new completion stage.
+     * @since 3.0
      */
     <U> CompletionStage<U> failedStage(Throwable ex);
 
@@ -354,6 +360,7 @@ public interface ManagedExecutorService extends ExecutorService {
      *
      * @return a <code>ContextService</code> with the same propagation settings
      *         as this <code>ManagedExecutorService</code>.
+     * @since 3.0
      */
     public ContextService getContextService();
 
@@ -366,6 +373,7 @@ public interface ManagedExecutorService extends ExecutorService {
      *
      * @param <U> result type of the completable future.
      * @return the new completable future.
+     * @since 3.0
      */
     <U> CompletableFuture<U> newIncompleteFuture();
 
@@ -380,6 +388,7 @@ public interface ManagedExecutorService extends ExecutorService {
      *
      * @param runnable the action to run before completing the returned completion stage.
      * @return the new completable future.
+     * @since 3.0
      */
     CompletableFuture<Void> runAsync(Runnable runnable);
 
@@ -395,6 +404,7 @@ public interface ManagedExecutorService extends ExecutorService {
      * @param supplier an action returning the value to be used to complete the returned completion stage.
      * @param <U> result type of the supplier and returned completable stage.
      * @return the new completable future.
+     * @since 3.0
      */
     <U> CompletableFuture<U> supplyAsync(Supplier<U> supplier);
 }

--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -27,7 +27,7 @@
     <groupId>jakarta.enterprise.concurrent</groupId>
     <artifactId>concurrency-spec</artifactId>
     <packaging>pom</packaging>
-    <version>2.0-SNAPSHOT</version>
+    <version>3.0-SNAPSHOT</version>
     <name>Jakarta Concurrency Specification</name>
 
     <properties>

--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -1,5 +1,5 @@
 :sectnums:
-= Jakarta Concurrency Specification, Version 2.0
+= Jakarta Concurrency Specification, Version 3.0
 
 Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 

--- a/specification/src/main/asciidoc/license-efsl.adoc
+++ b/specification/src/main/asciidoc/license-efsl.adoc
@@ -9,7 +9,7 @@ Status: {revremark}
 Release: {revdate}
 ....
 
-Copyright (c) 2018,2020 Eclipse Foundation.
+Copyright (c) 2018,2021 Eclipse Foundation.
 
 === Eclipse Foundation Specification License
 
@@ -47,9 +47,9 @@ specification is expressly prohibited.
 
 The notice is:
 
-"Copyright (c) 2020 Eclipse Foundation. This software or
+"Copyright (c) 2021 Eclipse Foundation. This software or
 document includes material copied from or derived from Jakarta Concurrency and 
-https://jakarta.ee/specifications/concurrency/2.0/."
+https://jakarta.ee/specifications/concurrency/3.0/."
 
 ==== Disclaimers
 


### PR DESCRIPTION
Update the version to 3.0 SNAPSHOT and ensure that `@since 3.0` is added to all new methods and classes.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>