### PR TITLE
Issue #38 ambiguity with more granular names

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedExecutorDefinition.java
@@ -109,6 +109,13 @@ public @interface ManagedExecutorDefinition {
      * or the JNDI name of the Jakarta EE default {@code ContextService}
      * instance, {@code java:comp/DefaultContextService}.
      * <p>
+     * The name of the {@code ContextService} must be no more granular
+     * than the name of this {@code ManagedExecutorDefinition}. For example,
+     * if this {@code ManagedExecutorDefinition} has a name in {@code java:app},
+     * the {@code ContextService} can be in {@code java:app} or {@code java:global},
+     * but not in {@code java:module} which would be ambiguous as to which
+     * module's {@code ContextService} definition should be used.
+     * <p>
      * The default value, {@code java:comp/DefaultContextService}, is the
      * JNDI name of the Jakarta EE default {@code ContextService}.
      *

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorDefinition.java
@@ -109,6 +109,13 @@ public @interface ManagedScheduledExecutorDefinition {
      * or the JNDI name of the Jakarta EE default {@code ContextService}
      * instance, {@code java:comp/DefaultContextService}.
      * <p>
+     * The name of the {@code ContextService} must be no more granular
+     * than the name of this {@code ManagedScheduledExecutorDefinition}. For example,
+     * if this {@code ManagedScheduledExecutorDefinition} has a name in {@code java:app},
+     * the {@code ContextService} can be in {@code java:app} or {@code java:global},
+     * but not in {@code java:module} which would be ambiguous as to which
+     * module's {@code ContextService} definition should be used.
+     * <p>
      * The default value, {@code java:comp/DefaultContextService}, is the
      * JNDI name of the Jakarta EE default {@code ContextService}.
      *

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedThreadFactoryDefinition.java
@@ -98,13 +98,23 @@ public @interface ManagedThreadFactoryDefinition {
     String name();
 
     /**
-     * <p>Determines how context is applied to threads from this
-     * thread factory.</p>
-     *
-     * <p>The default value indicates to use the default instance of
-     * {@link ContextService} by specifying a
-     * {@link ContextServiceDefinition} with the name
-     * <code>java:comp/DefaultContextService</code>.</p>
+     * Determines how context is applied to threads from this
+     * thread factory.
+     * <p>
+     * The name can be the name of a {@link ContextServiceDefinition} or
+     * the name of a {@code context-service} deployment descriptor element
+     * or the JNDI name of the Jakarta EE default {@code ContextService}
+     * instance, {@code java:comp/DefaultContextService}.
+     * <p>
+     * The name of the {@code ContextService} must be no more granular
+     * than the name of this {@code ManagedThreadFactoryDefinition}. For example,
+     * if this {@code ManagedThreadFactoryDefinition} has a name in {@code java:app},
+     * the {@code ContextService} can be in {@code java:app} or {@code java:global},
+     * but not in {@code java:module} which would be ambiguous as to which
+     * module's {@code ContextService} definition should be used.
+     * <p>
+     * The default value, {@code java:comp/DefaultContextService}, is the
+     * JNDI name of the Jakarta EE default {@code ContextService}.
      *
      * @return instructions for capturing and propagating or clearing context.
      */


### PR DESCRIPTION
When any of the other resource definitions refer to a context service definition by its name, the behavior is clear if the context service name is as granular or less granular than the other resource definition's name.  For example,

```
<managed-executor>
   <name>java:app/concurrent/executor1</name>
   <context-service-ref>java:app/concurrent/myContext1</context-service-ref>
</managed-executor>
<managed-executor>
   <name>java:app/concurrent/executor2</name>
   <context-service-ref>java:global/concurrent/myContext2</context-service-ref>
</managed-executor>
```

However, the behavior is unclear if referring to a context service definition with a more granular name, such as,

```
<managed-executor>
   <name>java:app/concurrent/myExecutor</name>
   <context-service-ref>java:comp/concurrent/myContext</context-service-ref>
</managed-executor>
```

It is unclear which component namespace this latter example refers to.  Different resources with the same name could exist in several.

This pull avoids the ambiguity by requiring that the context service name must be of the same or less granular scope.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>