### PR TITLE
Third-party context interferes with Serializable contextual proxies

### DIFF
--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -2366,6 +2366,15 @@ on a thread that will run the contextual task or action.
 . Invoke the `ThreadContextRestorer.endContext` method to restore the
 previous context after the contextual task or action completes.
 
+===== Third-Party Context and Serializable Contextual Proxies
+
+The SPI for third-party context providers does not permit the
+serialization of context. Therefore, when a contextual proxy is
+serialized, the Jakarta EE Product Provider does not serialize
+third-party context types. When the contextual proxy is deserialized,
+third-party context types that were configured to be propagated
+are ignored.
+
 ===== Usage Example
 
 This example supplies a `ThreadContextProvider` that turns priority


### PR DESCRIPTION
Update specification language to avoid causing serializable context proxies to be broken by default when third-party context providers (which cannot be serialized per spec) are present.  The ability to have serializable contextual proxies (they can be created by ContextService) is likely not very often used, but a fairly trivial update to specification wording can be made to allow this to continue working the same as it did in previous specification versions even if third-party thread context providers are added.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>