### PR TITLE
prevent overflow when advancing trigger

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/CronTrigger.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/CronTrigger.java
@@ -431,7 +431,7 @@ public class CronTrigger implements ZonedTrigger {
      * @return next date/time according to the cron schedule, or the original time if it matches.
      */
     protected ZonedDateTime next(final ZonedDateTime from) {
-        ZonedDateTime time = from.getNano() == 0 ? from : from.withNano(0).withSecond(from.getSecond() + 1);
+        ZonedDateTime time = from.getNano() == 0 ? from : from.plusSeconds(1).withNano(0);
 
         for (int i = 0; i < 1000 /** just in case expression never matches */ && time != null; ++i) {
             int year = time.getYear();

--- a/api/src/test/java/jakarta/enterprise/concurrent/CronTriggerTest.java
+++ b/api/src/test/java/jakarta/enterprise/concurrent/CronTriggerTest.java
@@ -870,6 +870,39 @@ public class CronTriggerTest {
     }
 
     /**
+     * Confirm proper advancement from 59 seconds into the next minute, and so forth.
+     */
+    @Test
+    public void testTriggerAdvancesAcrossUnits() {
+        ZoneId Hawaii = ZoneId.of("Pacific/Honolulu");
+
+        CronTrigger trigger = new CronTrigger(Hawaii)
+                .seconds("*/20")
+                .minutes("*/15")
+                .hours("*/12")
+                .daysOfMonth("1/8")
+                .months("JAN/6");
+
+        ZonedDateTime scheduledAt = ZonedDateTime.of(
+                2020, 12, 31, // Thursday, December 31, 2020
+                23, 59, 59, 0, // 11:59:59 PM
+                trigger.getZoneId());
+
+        ZonedDateTime time;
+        time = trigger.getNextRunTime(null, scheduledAt);
+        assertEquals(ZonedDateTime.of(2021, 1, 1, 0, 0, 0, 0, Hawaii), time);
+
+        time = trigger.getNextRunTime(new LastExecutionImpl(1, time), scheduledAt);
+        assertEquals(ZonedDateTime.of(2021, 1, 1, 0, 0, 20, 0, Hawaii), time);
+
+        time = trigger.getNextRunTime(new LastExecutionImpl(2, time), scheduledAt);
+        assertEquals(ZonedDateTime.of(2021, 1, 1, 0, 0, 40, 0, Hawaii), time);
+
+        time = trigger.getNextRunTime(new LastExecutionImpl(3, time), scheduledAt);
+        assertEquals(ZonedDateTime.of(2021, 1, 1, 0, 15, 0, 0, Hawaii), time);
+    }
+
+    /**
      * Specify a cron expression that very infrequently matches, such as leap days that are Fridays.
      */
     @Test


### PR DESCRIPTION
To avoid possible overflow, advancement needs to be done by the ZonedDateTime.plus method rather than setting a computed amount that might be out of range.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>