### PR TITLE
Prevent instantiation of Asynchronous.Result

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/Asynchronous.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Asynchronous.java
@@ -235,6 +235,10 @@ public @interface Asynchronous {
     public static class Result {
         private static final ThreadLocal<CompletableFuture<?>> FUTURES = new ThreadLocal<CompletableFuture<?>>();
 
+        // Prevent instantiation
+        private Result() {
+        }
+
         /**
          * Completes the {@link java.util.concurrent.CompletableFuture CompletableFuture}
          * instance that the Jakarta EE Product Provider supplies to the caller of the


### PR DESCRIPTION
I noticed this while adding the signature tests. It's currently possible for someone to write code that creates an instance of the Asynchronous.Result class, which is pointless.  This class is only intended to provide static methods for managing the result of asynchronous methods.  We should declare the default constructor private to prevent constructing instances and keep it out of the JavaDoc.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>