### PR TITLE
Fix checkstyle error for Asynchronous.Result

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/Asynchronous.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/Asynchronous.java
@@ -232,7 +232,7 @@ public @interface Asynchronous {
      *
      * @since 3.0
      */
-    public static class Result {
+    public static final class Result {
         private static final ThreadLocal<CompletableFuture<?>> FUTURES = new ThreadLocal<CompletableFuture<?>>();
 
         // Prevent instantiation


### PR DESCRIPTION
checkstyle is complaining that Asynchronous.Result needs to be declared final because its only constructor is private. This pull makes that update so that we won't see this warning when building the project.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>