### PR TITLE
Adding example to ContextServiceDefinition.unchanged()

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
@@ -144,11 +144,11 @@ public @interface ContextServiceDefinition {
      * runs the contextual task or action.
      * <p>For example, with <code> unchanged = TRANSACTION</code>
      * if a transaction is started after a function is
-     * contextualized, but before the function is run on the same thread, 
+     * contextualized, but before the function is run on the same thread,
      * the transaction will be active in the contextual function:</p>
-     * 
-     * <pre>Consumer<String, Integer> updateDB = contextService.contextualConsumer(fn);
-     * 
+     *
+     * <pre>Consumer&lt;String, Integer&gt; updateDB = contextService.contextualConsumer(fn);
+     *
      *&#47;/ later, on another thread
      *tx.begin();
      *updateDB.accept("java:comp/env/jdbc/ds1");

--- a/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ContextServiceDefinition.java
@@ -141,7 +141,19 @@ public @interface ContextServiceDefinition {
 
     /**
      * <p>Types of context that are left alone when a thread
-     * runs the contextual task or action.</p>
+     * runs the contextual task or action.
+     * <p>For example, with <code> unchanged = TRANSACTION</code>
+     * if a transaction is started after a function is
+     * contextualized, but before the function is run on the same thread, 
+     * the transaction will be active in the contextual function:</p>
+     * 
+     * <pre>Consumer<String, Integer> updateDB = contextService.contextualConsumer(fn);
+     * 
+     *&#47;/ later, on another thread
+     *tx.begin();
+     *updateDB.accept("java:comp/env/jdbc/ds1");
+     *&#47;/...additional transactional work
+     *tx.commit();</pre>
      *
      * <p>Constants are provided on this class for the context types
      * that are defined by the Jakarta EE Concurrency specification.</p>


### PR DESCRIPTION
I found an example helped me understand when unchanged is relevant and how it differs from cleared and propagated.

Rendered JavaDoc after the change:
![CSD unchanged](https://user-images.githubusercontent.com/21284019/145643946-f0e7ed85-79f8-42a8-9cfe-50e74a81f991.png)

