### PR TITLE
annotation toString differs between JDKs

### DIFF
--- a/tck/src/main/resources/WEB-INF/signaturetest/jakarta.enterprise.concurrent.Asynchronous.sig
+++ b/tck/src/main/resources/WEB-INF/signaturetest/jakarta.enterprise.concurrent.Asynchronous.sig
@@ -4,4 +4,4 @@
 @java.lang.annotation.Inherited()
 @java.lang.annotation.Retention(value=RUNTIME)
 @java.lang.annotation.Target(value={METHOD, TYPE})
-public abstract java.lang.String jakarta.enterprise.concurrent.Asynchronous.executor() [@jakarta.enterprise.util.Nonbinding()] default java:comp/DefaultManagedExecutorService
+@jakarta.enterprise.util.Nonbinding() public abstract java.lang.String jakarta.enterprise.concurrent.Asynchronous.executor() default java:comp/DefaultManagedExecutorService

--- a/tck/src/main/resources/WEB-INF/signaturetest/jakarta.enterprise.concurrent.ContextServiceDefinition.sig
+++ b/tck/src/main/resources/WEB-INF/signaturetest/jakarta.enterprise.concurrent.ContextServiceDefinition.sig
@@ -3,9 +3,9 @@
 @java.lang.annotation.Retention(value=RUNTIME)
 @java.lang.annotation.Target(value={TYPE})
 public abstract java.lang.String jakarta.enterprise.concurrent.ContextServiceDefinition.name()
-public abstract java.lang.String[] jakarta.enterprise.concurrent.ContextServiceDefinition.cleared() default [Transaction]
-public abstract java.lang.String[] jakarta.enterprise.concurrent.ContextServiceDefinition.propagated() default [Remaining]
-public abstract java.lang.String[] jakarta.enterprise.concurrent.ContextServiceDefinition.unchanged() default []
+public abstract java.lang.String[] jakarta.enterprise.concurrent.ContextServiceDefinition.cleared() default {Transaction}
+public abstract java.lang.String[] jakarta.enterprise.concurrent.ContextServiceDefinition.propagated() default {Remaining}
+public abstract java.lang.String[] jakarta.enterprise.concurrent.ContextServiceDefinition.unchanged() default {}
 public static final java.lang.String jakarta.enterprise.concurrent.ContextServiceDefinition.ALL_REMAINING
 public static final java.lang.String jakarta.enterprise.concurrent.ContextServiceDefinition.APPLICATION
 public static final java.lang.String jakarta.enterprise.concurrent.ContextServiceDefinition.SECURITY


### PR DESCRIPTION
Don't rely on annotation toString in the signature tests because its output is not standard and differs between JDKs.  The toString output was being used by the TCK as a shortcut for comparing the annotations on the method/class, which would have been nice if were a standard, but since it isn't, we need to replace this shortcut with a different approach that is more reliable.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>