### PR TITLE
prepare for 3.0 RC1 (still needs help - do not merge)

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,7 +29,7 @@
 
     <groupId>jakarta.enterprise.concurrent</groupId>
     <artifactId>jakarta.enterprise.concurrent-api</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0-RC1</version>
     <name>jakarta.enterprise.concurrent-api</name>
     <description>Jakarta Concurrency</description>
     <url>https://github.com/eclipse-ee4j/concurrency-api</url>
@@ -65,11 +65,11 @@
 
         <api_package>jakarta.enterprise.concurrent</api_package>
         <non.final>true</non.final>
-        <last.spec_version>1.1</last.spec_version>
-        <next.spec_version>2.0</next.spec_version>
+        <last.spec_version>2.0</last.spec_version>
+        <next.spec_version>3.0</next.spec_version>
         <spec.version>${next.spec_version}</spec.version>
-        <new.spec.version>3.0</new.spec.version>
-        <build_number />
+        <new.spec.version>3.1</new.spec.version>
+        <build_number>RC1</build_number>
         <packages.export>jakarta.enterprise.concurrent.*; version=${spec.bundle.version}</packages.export>
     </properties>
 
@@ -242,7 +242,7 @@
                     <doctitle>Jakarta Concurrency ${project.version} API specification</doctitle>
                     <header><![CDATA[<br>Jakarta Concurrency API v${project.version}]]></header>
                     <bottom>
-<![CDATA[Copyright (c) 2020 Eclipse Foundation.
+<![CDATA[Copyright (c) 2020,2022 Eclipse Foundation.
     Use is subject to
     <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.
 ]]>

--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  
-    Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
  
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,7 +27,7 @@
     <groupId>jakarta.enterprise.concurrent</groupId>
     <artifactId>concurrency-spec</artifactId>
     <packaging>pom</packaging>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.0.0-RC1</version>
     <name>Jakarta Concurrency Specification</name>
 
     <properties>
@@ -38,7 +38,7 @@
         <asciidoctorj.pdf.version>1.5.0-alpha.16</asciidoctorj.pdf.version>
         <jruby.version>9.2.6.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
-        <status>DRAFT</status>
+        <status>RELEASE CANDIDATE</status>
     </properties>
 
     <scm>

--- a/specification/src/main/asciidoc/jakarta-concurrency-spec.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency-spec.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017, 2020 Contributors to the Eclipse Foundation
+// Copyright (c) 2017, 2022 Contributors to the Eclipse Foundation
 //
 
 = Jakarta Concurrency

--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -1,7 +1,7 @@
 :sectnums:
 = Jakarta Concurrency Specification, Version 3.0
 
-Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
 
 Oracle and Java are registered trademarks of Oracle and/or its 
 affiliates. Other names may be trademarks of their respective owners. 

--- a/specification/src/main/asciidoc/license-efsl.adoc
+++ b/specification/src/main/asciidoc/license-efsl.adoc
@@ -9,7 +9,7 @@ Status: {revremark}
 Release: {revdate}
 ....
 
-Copyright (c) 2018,2021 Eclipse Foundation.
+Copyright (c) 2018,2022 Eclipse Foundation.
 
 === Eclipse Foundation Specification License
 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -52,7 +52,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         
         <jakarta.concurrent.version.ga>3.0.0</jakarta.concurrent.version.ga>
-        <jakarta.concurrent.version.dev>3.0.0-SNAPSHOT</jakarta.concurrent.version.dev>
+        <jakarta.concurrent.version.dev>3.0.0-RC1</jakarta.concurrent.version.dev>
         
         <!-- TODO update to 6.0.0 -->
         <jakarta.servlet.version>5.0.0</jakarta.servlet.version>


### PR DESCRIPTION
Updates to pom files for a RC1 pre-release that can be used by candidate compatible implementations.

Unfortunately, the updates I've made thus far aren't quite correct because they are producing a MANIFEST.MF with "99.bRC1" in the versions instead of 3.0.0.RC1

```
Bundle-Version: 3.0.99.bRC1
Export-Package: jakarta.enterprise.concurrent;version="3.0.99.bRC1";us
 es:="jakarta.enterprise.util,jakarta.interceptor",jakarta.enterprise.
 concurrent.spi;version="3.0.99.bRC1"
Specification-Version: 3.0.99.RC1
```

I don't know how to get this working, but hopefully by posting the updates someone will be able to spot what needs to be corrected.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>