### PR TITLE
Prepare for 3.0 release

### DIFF
--- a/specification/src/main/asciidoc/jakarta-concurrency-spec.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency-spec.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017, 2020 Contributors to the Eclipse Foundation
+// Copyright (c) 2017, 2022 Contributors to the Eclipse Foundation
 //
 
 = Jakarta Concurrency

--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -1,7 +1,7 @@
 :sectnums:
 = Jakarta Concurrency Specification, Version 3.0
 
-Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
 
 Oracle and Java are registered trademarks of Oracle and/or its 
 affiliates. Other names may be trademarks of their respective owners. 

--- a/specification/src/main/asciidoc/license-efsl.adoc
+++ b/specification/src/main/asciidoc/license-efsl.adoc
@@ -9,7 +9,7 @@ Status: {revremark}
 Release: {revdate}
 ....
 
-Copyright (c) 2018,2021 Eclipse Foundation.
+Copyright (c) 2018,2022 Eclipse Foundation.
 
 === Eclipse Foundation Specification License
 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.enterprise.concurrent</groupId>
     <artifactId>jakarta.enterprise.concurrent-tck</artifactId>
-    <version>3.0.0-RC1</version>
+    <version>3.0.0</version>
     <packaging>jar</packaging>
 
     <name>Jakarta Concurrency TCK</name>
@@ -52,7 +52,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         
         <jakarta.concurrent.version.ga>3.0.0</jakarta.concurrent.version.ga>
-        <jakarta.concurrent.version.dev>3.0.0-SNAPSHOT</jakarta.concurrent.version.dev>
+        <jakarta.concurrent.version.dev>3.0.0</jakarta.concurrent.version.dev>
         
         <!-- TODO update to 6.0.0 -->
         <jakarta.servlet.version>5.0.0</jakarta.servlet.version>


### PR DESCRIPTION
Update copyright years that might have been missed prior to a 3.0 final release.  If Jenkins will cover these for us as well, this pull can be discarded.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>