### PR TITLE
Ensure TCK includes non-class resources

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -112,4 +112,16 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
+    <build>
+	    <resources>
+	        <resource>
+	            <directory>src/main/java</directory>
+	            <includes>
+	                <include>**/*.xml</include>
+	                <include>**/*.sig</include>
+	                <include>**/*.jsp</include>
+	            </includes>
+	        </resource>
+	    </resources>
+	</build>
 </project>


### PR DESCRIPTION
Currently, we have files like `web.xml` and  `class.sig` files within the same package as the test class they are associated with to better aid in readability and encapsulation.  However, not all maven versions will automatically package non-class resources located within packages into the published artifact. This PR will ensure that these files are included. 