### PR TITLE
Allow building with Java 11

### DIFF
--- a/api/src/main/java/jakarta/enterprise/concurrent/CronTrigger.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/CronTrigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -36,7 +36,7 @@ import java.util.function.Function;
  * subclass this implementation or combine multiple <code>CronTrigger</code>
  * instances in a <code>Trigger</code> implementation of your own.
  * </p>
- * <table width="90%">
+ * <table>
  * <caption><b>Cron Expression Fields</b></caption>
  * <tr valign="top"><td>seconds (optional)</td><td>0-59, *. When absent, 0 is assumed</td></tr>
  * <tr valign="top"><td>minutes</td><td>0-59, *</td></tr>
@@ -48,7 +48,7 @@ import java.util.function.Function;
  *         and 7 for consistency with {@link java.time.DayOfWeek}.</td></tr>
  * </table>
  * <br>
- * <table width="90%">
+ * <table>
  * <caption><b>Cron Expression Syntax</b></caption>
  * <tr valign="top"><td><code>,</code></td>
  *     <td>delimits lists for all fields. For example, <code>MON,WED,FRI</code> or <code>MAY,SEP</code></td></tr>
@@ -68,7 +68,7 @@ import java.util.function.Function;
  *     <code>2L</code> indicates the second-to-last day, and so forth.</td></tr>
  * </table>
  * <br>
- * <table width="90%">
+ * <table>
  * <caption><b>Cron Expression Examples</b></caption>
  * <tr valign="top"><td><code>0 * * * *</code></td>
  *                  <td>every hour at the top of the hour</td></tr>

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorService.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -86,7 +86,8 @@ import java.util.concurrent.ScheduledExecutorService;
  * For example, if a task is repeating, the lifecycle of the task would be:<br>
  * (Note:  See {@link ManagedTaskListener} for task lifecycle management details.)
  *
- * <table summary="Task Lifecycle">
+ * <table>
+ * <caption>Task Lifecycle</caption>
  * <tr><td valign="top"><strong>Sequence</strong></td>
  *     <td valign="top"><strong>State</strong></td>
  *     <td valign="top"><strong>Action</strong></td>

--- a/api/src/main/java/jakarta/enterprise/concurrent/ManagedTaskListener.java
+++ b/api/src/main/java/jakarta/enterprise/concurrent/ManagedTaskListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,7 +46,8 @@ import java.util.concurrent.Future;
  * <img src="doc-files/TaskListener_StateDiagram.gif" alt="Task Listener State Diagram"><p>
  *
  * <b>A. The task runs normally:</b>
- * <table summary="Task Listener State Normal">
+ * <table>
+ * <caption>Task Listener State Normal</caption>
  * <tr><td valign="top"><strong><u>Sequence</u></strong></td>
  *     <td valign="top"><strong><u>State</u></strong></td>
  *     <td valign="top"><strong><u>Action</u></strong></td>
@@ -69,7 +70,8 @@ import java.util.concurrent.Future;
  * </table><p>
  *
  * <b>B. The task is cancelled during taskSubmitted():</b>
- * <table summary="Task Listener State Cancelled during taskSubmitted">
+ * <table>
+ * <caption>Task Listener State Cancelled during taskSubmitted</caption>
  * <tr><td valign="top"><strong><u>Sequence</u></strong></td>
  *     <td valign="top"><strong><u>State</u></strong></td>
  *     <td valign="top"><strong><u>Action</u></strong></td>
@@ -94,7 +96,8 @@ import java.util.concurrent.Future;
  *
  * <b>C. The task is cancelled or aborted after submitted, but before started:</b>
  *
- * <table summary="Task Listener State Cancelled after submitted but before started">
+ * <table>
+ * <caption>Task Listener State Cancelled after submitted but before started</caption>
  * <tr><td valign="top"><strong><u>Sequence</u></strong></td>
  *     <td valign="top"><strong><u>State</u></strong></td>
  *     <td valign="top"><strong><u>Action</u></strong></td>
@@ -119,7 +122,8 @@ import java.util.concurrent.Future;
  * </table> <p>
  *
  * <b>D. The task is cancelled when it is starting:</b>
- * <table summary="Task Listener State Cancelled when starting">
+ * <table>
+ * <caption>Task Listener State Cancelled when starting</caption>
  * <tr><td valign="top"><strong><u>Sequence</u></strong></td>
  *     <td valign="top"><strong><u>State</u></strong></td>
  *     <td valign="top"><strong><u>Action</u></strong></td>

--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -70,8 +70,8 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.8.0,1.9.0)</version>
-                                    <message>You need JDK8 or lower</message>
+                                    <version>[1.8.0,12.0)</version>
+                                    <message>You need JDK11 or lower</message>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>

--- a/specification/src/main/asciidoc/jakarta-concurrency-spec.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency-spec.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017, 2020 Contributors to the Eclipse Foundation
+// Copyright (c) 2017, 2022 Contributors to the Eclipse Foundation
 //
 
 = Jakarta Concurrency

--- a/specification/src/main/asciidoc/jakarta-concurrency.adoc
+++ b/specification/src/main/asciidoc/jakarta-concurrency.adoc
@@ -1,7 +1,7 @@
 :sectnums:
 = Jakarta Concurrency Specification, Version 3.0
 
-Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
 
 Oracle and Java are registered trademarks of Oracle and/or its 
 affiliates. Other names may be trademarks of their respective owners. 

--- a/specification/src/main/asciidoc/license-efsl.adoc
+++ b/specification/src/main/asciidoc/license-efsl.adoc
@@ -9,7 +9,7 @@ Status: {revremark}
 Release: {revdate}
 ....
 
-Copyright (c) 2018,2021 Eclipse Foundation.
+Copyright (c) 2018,2022 Eclipse Foundation.
 
 === Eclipse Foundation Specification License
 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.enterprise.concurrent</groupId>
     <artifactId>jakarta.enterprise.concurrent-tck</artifactId>
-    <version>3.0.0-RC1</version>
+    <version>3.0.0</version>
     <packaging>jar</packaging>
 
     <name>Jakarta Concurrency TCK</name>
@@ -52,7 +52,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         
         <jakarta.concurrent.version.ga>3.0.0</jakarta.concurrent.version.ga>
-        <jakarta.concurrent.version.dev>3.0.0-SNAPSHOT</jakarta.concurrent.version.dev>
+        <jakarta.concurrent.version.dev>3.0.0</jakarta.concurrent.version.dev>
         
         <!-- TODO update to 6.0.0 -->
         <jakarta.servlet.version>5.0.0</jakarta.servlet.version>


### PR DESCRIPTION
After switching to Java 11 to build the tck, I realized that the api and specification builds fail with Java 11.

In the case of /specification/, it's just an artificial limitation imposed by requireJavaVersion which we can easily relax.

In the case of /api/, there are these errors with the JavaDoc using some no-longer-available HTML attributes,

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.2.0:jar (attach-javadocs) on project jakarta.enterprise.concurrent-api: MavenReportException: Error while generating Javadoc: 
[ERROR] Exit code: 1 - /Users/njr/lgit/concurrency-api/api/src/main/java/jakarta/enterprise/concurrent/ManagedScheduledExecutorService.java:89: error: attribute not supported in HTML5: summary
[ERROR]  * <table summary="Task Lifecycle">
[ERROR]           ^
[ERROR] /Users/njr/lgit/concurrency-api/api/src/main/java/jakarta/enterprise/concurrent/CronTrigger.java:39: error: attribute not supported in HTML5: width
[ERROR]  * <table width="90%">
[ERROR]           ^
[ERROR] /Users/njr/lgit/concurrency-api/api/src/main/java/jakarta/enterprise/concurrent/CronTrigger.java:51: error: attribute not supported in HTML5: width
[ERROR]  * <table width="90%">
[ERROR]           ^
[ERROR] /Users/njr/lgit/concurrency-api/api/src/main/java/jakarta/enterprise/concurrent/CronTrigger.java:71: error: attribute not supported in HTML5: width
[ERROR]  * <table width="90%">
[ERROR]           ^
[ERROR] /Users/njr/lgit/concurrency-api/api/src/main/java/jakarta/enterprise/concurrent/ManagedTaskListener.java:49: error: attribute not supported in HTML5: summary
[ERROR]  * <table summary="Task Listener State Normal">
[ERROR]           ^
[ERROR] /Users/njr/lgit/concurrency-api/api/src/main/java/jakarta/enterprise/concurrent/ManagedTaskListener.java:72: error: attribute not supported in HTML5: summary
[ERROR]  * <table summary="Task Listener State Cancelled during taskSubmitted">
[ERROR]           ^
[ERROR] /Users/njr/lgit/concurrency-api/api/src/main/java/jakarta/enterprise/concurrent/ManagedTaskListener.java:97: error: attribute not supported in HTML5: summary
[ERROR]  * <table summary="Task Listener State Cancelled after submitted but before started">
[ERROR]           ^
[ERROR] /Users/njr/lgit/concurrency-api/api/src/main/java/jakarta/enterprise/concurrent/ManagedTaskListener.java:122: error: attribute not supported in HTML5: summary
[ERROR]  * <table summary="Task Listener State Cancelled when starting">
```

To get this to build, I replaced table `summary` with `caption` and omitted the `width="90%"` altogether because it didn't make any noticeable difference.  Now either Java 11 or Java 8 can be used for builds.

Along with this, I've updated the copyright to include 2022 for the specification and set the tck version to 3.0.0 because tooling won't know about it to switch its version automatically.


Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>