### PR TITLE
Set the property to indicate a final release so that MANIFEST.MF gets correct versions

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -35,11 +35,11 @@
     <properties>
 
         <api_package>jakarta.enterprise.concurrent</api_package>
-        <non.final>true</non.final>
-        <last.spec_version>1.1</last.spec_version>
-        <next.spec_version>2.0</next.spec_version>
+        <non.final>false</non.final> <!-- switch back to true once release is completed -->
+        <last.spec_version>2.0</last.spec_version>
+        <next.spec_version>3.0</next.spec_version>
         <spec.version>${next.spec_version}</spec.version>
-        <new.spec.version>3.0</new.spec.version>
+        <new.spec.version>3.1</new.spec.version>
         <build_number />
         <packages.export>jakarta.enterprise.concurrent.*; version=${spec.bundle.version}</packages.export>
     </properties>


### PR DESCRIPTION
Avoid ending up with bnull and null in MANIFEST.MF of the API jar by setting the property in the pom to indicate that this will be a final release.

Here is the sort of versions we got before:

```
Bundle-Version: 2.0.99.bnull
Export-Package: jakarta.enterprise.concurrent;version="2.0.99.bnull";u
 ses:="jakarta.enterprise.util,jakarta.interceptor",jakarta.enterprise
 .concurrent.spi;version="2.0.99.bnull"
...
Specification-Version: 2.0.99.null
```

After making this change locally, I get the following instead:

```
Bundle-Version: 3.0.0
Export-Package: jakarta.enterprise.concurrent;version="3.0.0";uses:="j
 akarta.enterprise.util,jakarta.interceptor",jakarta.enterprise.concur
 rent.spi;version="3.0.0"
...
Specification-Version: 3.0
```

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>