### PR TITLE
test new resource definition elements in deployment descriptor

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/dd/DeploymentDescriptorServlet.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/dd/DeploymentDescriptorServlet.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.concurrent.spec.Platform.dd;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import ee.jakarta.tck.concurrent.common.context.IntContext;
+import ee.jakarta.tck.concurrent.common.context.StringContext;
+import ee.jakarta.tck.concurrent.framework.TestServlet;
+import jakarta.annotation.Resource;
+import jakarta.ejb.EJB;
+import jakarta.enterprise.concurrent.ContextService;
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.transaction.Status;
+import jakarta.transaction.UserTransaction;
+
+@WebServlet("DeploymentDescriptorServlet")
+public class DeploymentDescriptorServlet extends TestServlet {
+    private static final long serialVersionUID = 1L;
+    private static final long MAX_WAIT_SECONDS = TimeUnit.MINUTES.toSeconds(2);
+
+    @EJB
+    DeploymentDescriptorTestBeanInterface enterpriseBean;
+
+    @Resource
+    UserTransaction tx;    
+
+    /**
+     * Tests context-service defined in a deployment descriptor.
+     */
+    public void testDeploymentDescriptorDefinesContextService() throws Throwable {
+        ContextService contextSvc = InitialContext.doLookup("java:global/concurrent/ContextD");
+ 
+        Callable<Integer> checkContextAndGetTransactionStatus;
+
+        tx.begin();
+        try {
+            IntContext.set(1001);
+            StringContext.set("testDeploymentDescriptorDefinesContextService-1");
+
+            checkContextAndGetTransactionStatus = contextSvc.contextualCallable(() -> {
+                assertEquals(IntContext.get(), 0); // cleared
+                assertEquals(StringContext.get(), "testDeploymentDescriptorDefinesContextService-1"); // propagated
+                assertNotNull(InitialContext.doLookup("java:app/concurrent/ExecutorD")); // propagated
+                return tx.getStatus(); // unchanged
+            });
+
+            StringContext.set("testDeploymentDescriptorDefinesContextService-2");
+
+            int status = checkContextAndGetTransactionStatus.call();
+            assertEquals(status, Status.STATUS_ACTIVE);
+
+            assertEquals(IntContext.get(), 1001); // restored
+            assertEquals(StringContext.get(), "testDeploymentDescriptorDefinesContextService-2"); // restored
+        } finally {
+            IntContext.set(0);
+            StringContext.set(null);
+            tx.rollback();
+        }
+
+        int status = checkContextAndGetTransactionStatus.call();
+        assertEquals(status, Status.STATUS_NO_TRANSACTION);
+    }
+
+    /**
+     * Tests managed-executor defined in a deployment descriptor.
+     */
+    public void testDeploymentDescriptorDefinesManagedExecutor() throws Throwable {
+        LinkedBlockingQueue<Object> started = new LinkedBlockingQueue<Object>();
+        CountDownLatch taskCanEnd = new CountDownLatch(1);
+
+        Supplier<String> task = () -> {
+            try {
+                started.add(InitialContext.doLookup("java:app/concurrent/ExecutorD")); // requires Application context
+                assertTrue(taskCanEnd.await(MAX_WAIT_SECONDS, TimeUnit.SECONDS));
+            } catch (InterruptedException | NamingException x) {
+                throw new CompletionException(x);
+            }
+            return StringContext.get();
+        };
+
+        ManagedExecutorService executor = InitialContext.doLookup("java:app/concurrent/ExecutorD");
+
+        try {
+            StringContext.set("testDeploymentDescriptorDefinesManagedExecutor-1");
+            CompletableFuture<String> future1 = executor.supplyAsync(task);
+
+            StringContext.set("testDeploymentDescriptorDefinesManagedExecutor-2");
+            CompletableFuture<String> future2 = executor.supplyAsync(task);
+
+            StringContext.set("testDeploymentDescriptorDefinesManagedExecutor-3");
+            CompletableFuture<String> future3 = executor.supplyAsync(task);
+
+            StringContext.set("testDeploymentDescriptorDefinesManagedExecutor-4");
+            CompletableFuture<String> future4 = executor.supplyAsync(task);
+
+            StringContext.set("testDeploymentDescriptorDefinesManagedExecutor-5");
+
+            // 3 can start per max-async
+            assertNotNull(started.poll(MAX_WAIT_SECONDS, TimeUnit.SECONDS));
+            assertNotNull(started.poll(MAX_WAIT_SECONDS, TimeUnit.SECONDS));
+            assertNotNull(started.poll(MAX_WAIT_SECONDS, TimeUnit.SECONDS));
+            assertEquals(started.poll(1, TimeUnit.SECONDS), null);
+
+            taskCanEnd.countDown();
+
+            assertEquals(future1.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS), "testDeploymentDescriptorDefinesManagedExecutor-1");
+            assertEquals(future2.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS), "testDeploymentDescriptorDefinesManagedExecutor-2");
+            assertEquals(future3.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS), "testDeploymentDescriptorDefinesManagedExecutor-3");
+            assertEquals(future4.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS), "testDeploymentDescriptorDefinesManagedExecutor-4");
+
+            assertNotNull(started.poll(MAX_WAIT_SECONDS, TimeUnit.SECONDS));
+        } finally {
+            IntContext.set(0);
+            StringContext.set(null);
+        }
+    }
+
+    /**
+     * Tests managed-scheduled-executor defined in a deployment descriptor.
+     */
+    public void testDeploymentDescriptorDefinesManagedScheduledExecutor() throws Throwable {
+        enterpriseBean.testDeploymentDescriptorDefinesManagedScheduledExecutor();
+    }
+
+    /**
+     * Tests managed-thread-factory defined in a deployment descriptor.
+     */
+    public void testDeploymentDescriptorDefinesManagedThreadFactory() throws Throwable {
+        enterpriseBean.testDeploymentDescriptorDefinesManagedThreadFactory();
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/dd/DeploymentDescriptorTestBean.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/dd/DeploymentDescriptorTestBean.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.concurrent.spec.Platform.dd;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import ee.jakarta.tck.concurrent.common.context.IntContext;
+import ee.jakarta.tck.concurrent.common.context.StringContext;
+
+import jakarta.ejb.EJBException;
+import jakarta.ejb.Local;
+import jakarta.ejb.Stateless;
+import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
+import jakarta.enterprise.concurrent.ManagedThreadFactory;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+@Local(DeploymentDescriptorTestBeanInterface.class)
+@Stateless
+public class DeploymentDescriptorTestBean implements DeploymentDescriptorTestBeanInterface {
+    private static final long MAX_WAIT_SECONDS = TimeUnit.MINUTES.toSeconds(2);
+
+    @Override
+    public void testDeploymentDescriptorDefinesManagedScheduledExecutor() {
+        try {
+            LinkedBlockingQueue<Integer> started = new LinkedBlockingQueue<Integer>();
+            CountDownLatch taskCanEnd = new CountDownLatch(1);
+
+            Callable<String> task = () -> {
+                started.add(IntContext.get());
+                assertTrue(taskCanEnd.await(MAX_WAIT_SECONDS, TimeUnit.SECONDS));
+                return StringContext.get();
+            };
+
+            ManagedScheduledExecutorService executor = InitialContext.doLookup("java:global/concurrent/ScheduledExecutorD");
+
+            IntContext.set(3000);
+
+            StringContext.set("testDeploymentDescriptorDefinesManagedScheduledExecutor-1");
+            Future<String> future1 = executor.submit(task);
+
+            StringContext.set("testDeploymentDescriptorDefinesManagedScheduledExecutor-2");
+            Future<String> future2 = executor.submit(task);
+
+            StringContext.set("testDeploymentDescriptorDefinesManagedScheduledExecutor-3");
+            Future<String> future3 = executor.submit(task);
+
+            StringContext.set("testDeploymentDescriptorDefinesManagedScheduledExecutor-4");
+
+            // 2 can start per max-async
+            assertEquals(started.poll(MAX_WAIT_SECONDS, TimeUnit.SECONDS), Integer.valueOf(0));
+            assertEquals(started.poll(MAX_WAIT_SECONDS, TimeUnit.SECONDS), Integer.valueOf(0));
+            assertEquals(started.poll(1, TimeUnit.SECONDS), null);
+
+            taskCanEnd.countDown();
+
+            assertEquals(future1.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS), "testDeploymentDescriptorDefinesManagedScheduledExecutor-1");
+            assertEquals(future2.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS), "testDeploymentDescriptorDefinesManagedScheduledExecutor-2");
+            assertEquals(future3.get(MAX_WAIT_SECONDS, TimeUnit.SECONDS), "testDeploymentDescriptorDefinesManagedScheduledExecutor-3");
+
+            assertEquals(started.poll(MAX_WAIT_SECONDS, TimeUnit.SECONDS), Integer.valueOf(0));
+        } catch (ExecutionException | InterruptedException | NamingException | TimeoutException x) {
+            throw new EJBException(x);
+        } finally {
+            IntContext.set(0);
+            StringContext.set(null);
+        }
+    }
+
+    @Override
+    public void testDeploymentDescriptorDefinesManagedThreadFactory() {
+        try {
+            IntContext.set(4000);
+            StringContext.set("testDeploymentDescriptorDefinesManagedThreadFactory-1");
+
+            ManagedThreadFactory threadFactory =
+                    (ManagedThreadFactory) InitialContext.doLookup("java:app/concurrent/ThreadFactoryD");
+
+            StringContext.set("testDeploymentDescriptorDefinesManagedThreadFactory-2");
+
+            LinkedBlockingQueue<Object> results = new LinkedBlockingQueue<>();
+
+            Thread thread = threadFactory.newThread(() -> {
+                results.add(Thread.currentThread().getPriority());
+                results.add(IntContext.get());
+                results.add(StringContext.get());
+                try {
+                    results.add(InitialContext.doLookup("java:app/concurrent/ThreadFactoryD"));
+                } catch (Exception x) {
+                    results.add(x);
+                }
+            });
+
+            assertEquals(thread.getPriority(), 6); // configured value on managed-thread-factory
+
+            thread.start();
+
+            assertEquals(results.poll(MAX_WAIT_SECONDS, TimeUnit.SECONDS), Integer.valueOf(6)); // priority from managed-thread-factory
+            assertEquals(results.poll(MAX_WAIT_SECONDS, TimeUnit.SECONDS), Integer.valueOf(0)); // IntContext cleared
+            assertEquals(results.poll(MAX_WAIT_SECONDS, TimeUnit.SECONDS), "testDeploymentDescriptorDefinesManagedThreadFactory-1"); // propagated
+            Object lookupResult = results.poll(MAX_WAIT_SECONDS, TimeUnit.SECONDS);
+            if (lookupResult instanceof Exception)
+                throw new EJBException((Exception) lookupResult);
+            assertNotNull(lookupResult);
+
+        } catch (InterruptedException | NamingException x) {
+            throw new EJBException(x);
+        } finally {
+            IntContext.set(0);
+            StringContext.set(null);
+        }
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/dd/DeploymentDescriptorTestBeanInterface.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/dd/DeploymentDescriptorTestBeanInterface.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.concurrent.spec.Platform.dd;
+
+import javax.naming.NamingException;
+
+public interface DeploymentDescriptorTestBeanInterface {
+
+    void testDeploymentDescriptorDefinesManagedScheduledExecutor();
+
+    void testDeploymentDescriptorDefinesManagedThreadFactory();
+}

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/dd/DeploymentDescriptorTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/dd/DeploymentDescriptorTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.concurrent.spec.Platform.dd;
+
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import ee.jakarta.tck.concurrent.framework.TestClient;
+import ee.jakarta.tck.concurrent.framework.URLBuilder;
+import ee.jakarta.tck.concurrent.spi.context.IntContextProvider;
+import ee.jakarta.tck.concurrent.spi.context.StringContextProvider;
+import jakarta.enterprise.concurrent.spi.ThreadContextProvider;
+
+/**
+ * Covers context-service, managed-executor, managed-scheduled-executor,
+ * and managed-thread-factory defined in a deployment descriptor.
+ */
+public class DeploymentDescriptorTests extends TestClient{
+    
+    @ArquillianResource(DeploymentDescriptorServlet.class)
+    URL baseURL;
+    
+    @Deployment(name="DeploymentDescriptorTests", testable=false)
+    public static EnterpriseArchive createDeployment() {
+        
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "DeploymentDescriptorTests_web.war")
+                .addPackages(false,
+                        getFrameworkPackage()) 
+                .addClasses(
+                        DeploymentDescriptorServlet.class);
+
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "DeploymentDescriptorTests_ejb.jar")
+                .addClasses(
+                        DeploymentDescriptorTestBean.class,
+                        DeploymentDescriptorTestBeanInterface.class)
+                .addPackages(true,
+                        getContextPackage(),
+                        getContextProvidersPackage())
+                .addAsServiceProvider(ThreadContextProvider.class.getName(),
+                        IntContextProvider.class.getName(),
+                        StringContextProvider.class.getName());
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "DeploymentDescriptorTests.ear")
+                .addAsManifestResource(DeploymentDescriptorTests.class.getPackage(), "application.xml", "application.xml")
+                .addAsModules(war, jar);
+
+        return ear;
+    }
+    
+    @Override
+    protected String getServletPath() {
+        return "DeploymentDescriptorServlet";
+    }
+    
+    @Test
+    public void testDeploymentDescriptorDefinesContextService() {
+        runTest(baseURL);
+    }
+
+    @Test
+    public void testDeploymentDescriptorDefinesManagedExecutor() {
+        runTest(baseURL);
+    }
+
+    @Test
+    public void testDeploymentDescriptorDefinesManagedScheduledExecutor() {
+        runTest(baseURL);
+    }
+
+    @Test
+    public void testDeploymentDescriptorDefinesManagedThreadFactory() {
+        runTest(baseURL);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/dd/application.xml
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/Platform/dd/application.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Contributors to the Eclipse Foundation
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<application version="10"
+             xmlns="https://jakarta.ee/xml/ns/jakartaee"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
+
+  <module>
+    <web>
+      <web-uri>DeploymentDescriptorTests_web.war</web-uri>
+      <context-root>/</context-root>
+    </web>
+  </module>
+
+  <module>
+    <ejb>DeploymentDescriptorTests_ejb.jar</ejb>
+  </module>
+
+  <context-service>
+    <name>java:global/concurrent/ContextD</name>
+    <cleared>IntContext</cleared>
+    <propagated>Application</propagated>
+    <propagated>StringContext</propagated>
+    <unchanged>Transaction</unchanged>
+  </context-service>
+
+  <managed-executor>
+    <name>java:app/concurrent/ExecutorD</name>
+    <context-service-ref>java:global/concurrent/ContextD</context-service-ref>
+    <max-async>3</max-async>
+  </managed-executor>
+
+  <managed-scheduled-executor>
+    <name>java:global/concurrent/ScheduledExecutorD</name>
+    <context-service-ref>java:global/concurrent/ContextD</context-service-ref>
+    <max-async>2</max-async>
+    <hung-task-threshold>200000</hung-task-threshold>
+  </managed-scheduled-executor>
+
+  <managed-thread-factory>
+    <name>java:app/concurrent/ThreadFactoryD</name>
+    <context-service-ref>java:global/concurrent/ContextD</context-service-ref>
+    <priority>6</priority>
+  </managed-thread-factory>
+
+</application>


### PR DESCRIPTION
A recent discussion with on the mailing list with @smillidge "Javadoc implies a deployment descriptor" reminded me that tests for the new deployment elements (such as `<managed-executor>` and `<context-service>`) need to be added for platform coverage.  But since the old platform TCK is being removed, and because there's still a little bit of time for us to get updates into the new TCK in the Concurrency project while the signature tests are being cleaned up, I've created this pull to add these deployment descriptor element tests here, which should then make it unnecessary to add to the platform TCK, hopefully making that removal effort smoother.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>