### PR TITLE
fix ContextTests deployment, put ejb classes only into jar

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedThreadFactory/context/ContextTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedThreadFactory/context/ContextTests.java
@@ -37,6 +37,8 @@ public class ContextTests extends TestClient {
 	public static EnterpriseArchive createDeployment() {
 		WebArchive war = ShrinkWrap.create(WebArchive.class)
 				.addPackages(true, getFrameworkPackage(), getCommonPackage(), ContextTests.class.getPackage())
+				.deleteClass(SecurityTestEjb.class) // SecurityTestEjb and SecurityTestRemote are in the jar
+				.deleteClass(SecurityTestRemote.class)
 				.addAsWebInfResource(ContextTests.class.getPackage(), "web.xml", "web.xml");
 		
 		JavaArchive jar = ShrinkWrap.create(JavaArchive.class)


### PR DESCRIPTION
ContextTests is a broken test, it tries to deploy classes SecurityTestEjb and SecurityTestRemote in both jar and war inside one ear.