### PR TITLE
Remove remaining version from signature tests

### DIFF
--- a/tck/README.md
+++ b/tck/README.md
@@ -286,7 +286,7 @@ In this case use:
 ```
 
 
-For more information about generating the signature test file, and how the test run read: [ee.jakarta.tck.concurrent.framework.signaturetest/README.md][src/main/java/ee/jakarta/tck/concurrent/framework/signaturetest/README.md]
+For more information about generating the signature test file, and how the test run read: [ee.jakarta.tck.concurrent.framework.signaturetest/README.md](https://github.com/eclipse-ee4j/concurrency-api/blob/master/tck/src/main/java/ee/jakarta/tck/concurrent/framework/signaturetest/README.md)
 
 
 ### Advanced Configuration

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/framework/signaturetest/SigTestEE.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/framework/signaturetest/SigTestEE.java
@@ -283,38 +283,6 @@ public abstract class SigTestEE {
 				throw new Exception();
 			}
 
-			// Call verifyJtaJarTest based on some conditions, please check the
-			// comment for verifyJtaJarTest.
-			if ("standalone".equalsIgnoreCase(testInfo.getVehicle())) {
-				Properties mapFileAsProps = getSigTestDriver().loadMapFile(mapFile);
-				if (mapFileAsProps == null || mapFileAsProps.size() == 0) {
-					// empty signature file, something unusual
-					System.out.println("SigTestEE.signatureTest() returning, " + "as signature map file is empty.");
-					return;
-				}
-
-				boolean isJTASigTest = false;
-
-				// Determine whether the signature map file contains package
-				// jakarta.transaction
-				String jtaVersion = mapFileAsProps.getProperty("jakarta.transaction");
-				if (jtaVersion == null || "".equals(jtaVersion.trim())) {
-					System.out.println("SigTestEE.signatureTest() returning, "
-							+ "as this is neither JTA TCK run, not Java EE CTS run.");
-					return;
-				}
-
-				System.out.println("jtaVersion " + jtaVersion);
-				// Signature map packaged in JTA TCK will contain a single package
-				// jakarta.transaction
-				if (mapFileAsProps.size() == 1) {
-					isJTASigTest = true;
-				}
-
-				if (isJTASigTest || !jtaVersion.startsWith("1.2")) {
-					verifyJtaJarTest();
-				}
-			}
 			System.out.println("$$$ SigTestEE.signatureTest() returning");
 		} catch (Exception e) {
 			if (results != null && !results.passed()) {
@@ -324,40 +292,6 @@ public abstract class SigTestEE {
 				throw new Fault("signatureTest failed with an unexpected exception", e);
 			}
 		}
-	}
-
-	/**
-	 * Called by the test framework to run this test. This method utilizes the state
-	 * information set in the setup method to run. This test validates that the
-	 * javax.transaction.xa type is not in the JTA API jar
-	 *
-	 * This method is called only for standaone vehicle, as calling the same for all
-	 * the vehicles in the CTS run is not necessary.
-	 *
-	 * This method is called always from JTA 1.3 TCK. The test will be run as part
-	 * of Java EE Signature Test only when the signature map in the CTS bundle is
-	 * using JTA 1.3 (or higher) signature file.
-	 *
-	 * If property ts.jte jtaJarClasspath is removed in ts.jte of the JTA 1.3 TCK,
-	 * this test will display the available options to call SignatureTest and fail.
-	 * Similar failure will be seen in CTS run, if the signature map points to JTA
-	 * 1.3 signature file and the property jtaJarClasspath is removed from ts.jte of
-	 * CTS bundle.
-	 *
-	 * @throws Fault When an error occurs executing the signature tests.
-	 */
-	public void verifyJtaJarTest() throws Exception {
-		System.out.println("SigTestEE#verifyJtaJarTest - Starting:");
-		String repositoryDir = getRepositoryDir();
-		String jtaJarClasspath = testInfo.getJtaJarClasspath();
-		boolean result = getSigTestDriver().verifyJTAJarForNoXA(testInfo.getJtaJarClasspath(), repositoryDir);
-		if (result) {
-			System.out.println("PASS: javax.transaction.xa not found in API jar");
-		} else {
-			System.out.println("FAIL: javax.transaction.xa found in API jar");
-			throw new Fault("javax.transaction.xa validation failed");
-		}
-		System.out.println("SigTestEE#verifyJtaJarTest returning");
 	}
 
 	/**

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/framework/signaturetest/SignatureTestDriver.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/framework/signaturetest/SignatureTestDriver.java
@@ -33,8 +33,6 @@ public abstract class SignatureTestDriver {
 
 	private static final String SIG_FILE_EXT = ".sig";
 
-	private static final String SIG_FILE_VER_SEP = "_";
-
 	// ---------------------------------------------------------- Public Methods
 
 	/**
@@ -462,9 +460,9 @@ public abstract class SignatureTestDriver {
 
 		String sigFile;
 		if (repositoryDir.endsWith(File.separator)) {
-			sigFile = repositoryDir + baseName + SIG_FILE_EXT + SIG_FILE_VER_SEP + version;
+			sigFile = repositoryDir + baseName + SIG_FILE_EXT;
 		} else {
-			sigFile = repositoryDir + File.separator + baseName + SIG_FILE_EXT + SIG_FILE_VER_SEP + version;
+			sigFile = repositoryDir + File.separator + baseName + SIG_FILE_EXT;
 		}
 
 		File testFile = new File(sigFile);

--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/signature/ConcurrencySigTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/signature/ConcurrencySigTest.java
@@ -275,37 +275,6 @@ public class ConcurrencySigTest extends SigTestEE {
 				throw new Exception();
 			}
 
-			// Call verifyJtaJarTest based on some conditions, please check the
-			// comment for verifyJtaJarTest.
-			if ("standalone".equalsIgnoreCase(testInfo.getVehicle())) {
-				if (mapFileAsProps == null || mapFileAsProps.size() == 0) {
-					// empty signature file, something unusual
-					log.info("ConcurrencySigTest.signatureTest() returning, " + "as signature map file is empty.");
-					return;
-				}
-
-				boolean isJTASigTest = false;
-
-				// Determine whether the signature map file contains package
-				// jakarta.transaction
-				String jtaVersion = mapFileAsProps.getProperty("jakarta.transaction");
-				if (jtaVersion == null || "".equals(jtaVersion.trim())) {
-					log.info("ConcurrencySigTest.signatureTest() returning, "
-							+ "as this is neither JTA TCK run, not Java EE CTS run.");
-					return;
-				}
-
-				log.info("jtaVersion " + jtaVersion);
-				// Signature map packaged in JTA TCK will contain a single package
-				// jakarta.transaction
-				if (mapFileAsProps.size() == 1) {
-					isJTASigTest = true;
-				}
-
-				if (isJTASigTest || !jtaVersion.startsWith("1.2")) {
-					verifyJtaJarTest();
-				}
-			}
 			log.info("$$$ ConcurrencySigTest.signatureTest() returning");
 		} catch (Exception e) {
 			if (results != null && !results.passed()) {

--- a/tck/src/main/resources/ee/jakarta/tck/concurrent/spec/signature/sig-test.map
+++ b/tck/src/main/resources/ee/jakarta/tck/concurrent/spec/signature/sig-test.map
@@ -17,4 +17,4 @@
 ###############################################################
 # The signature test mapping file for the Concurrency TCK.
 ###############################################################
-jakarta.enterprise.concurrent=3.0.0
+jakarta.enterprise.concurrent=


### PR DESCRIPTION
Addresses comment in #195 to remove the remaining occurrence of a spec version number from files within the Concurrency TCK.  This will make for a seamless transition between spec releases and will be one less place where developers need to know that they must manually update a version number.

Also, I fixed a broken link in the signature test section of the readme.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>