### PR TITLE
Intermittent threading bug in TCK testScheduleWithZonedTrigger

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionServlet.java
+++ b/tck/src/main/java/ee/jakarta/tck/concurrent/spec/ManagedScheduledExecutorService/resourcedef/ManagedScheduledExecutorDefinitionServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,7 +22,6 @@ import static org.testng.Assert.assertTrue;
 import java.time.DayOfWeek;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
@@ -544,7 +543,7 @@ public class ManagedScheduledExecutorDefinitionServlet extends TestServlet {
 
         ZoneId US_CENTRAL = ZoneId.of("America/Chicago");
 
-        Map<ZonedDateTime, ZonedDateTime> startAndEndTimes = new HashMap<ZonedDateTime, ZonedDateTime>();
+        Map<ZonedDateTime, ZonedDateTime> startAndEndTimes = new ConcurrentHashMap<ZonedDateTime, ZonedDateTime>();
 
         Trigger monthlyOnThe15th = new ZonedTrigger() {
             final Map<Long, ZonedDateTime> schedule = new ConcurrentHashMap<Long, ZonedDateTime>();


### PR DESCRIPTION
In our automated testing with the Concurrency TCK, we observed testScheduleWithZonedTrigger to fail once with an intermittent threading error:

```
[3/24/22, 5:33:52:075 PDT] 00000068 ee.jakarta.tck.concurrent.framework.TestServlet              W Caught exception attempting to call test method testScheduleWithZonedTrigger on servlet ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionServlet
java.util.ConcurrentModificationException
	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1493)
	at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1526)
	at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1524)
	at ee.jakarta.tck.concurrent.spec.ManagedScheduledExecutorService.resourcedef.ManagedScheduledExecutorDefinitionServlet.testScheduleWithZonedTrigger(ManagedScheduledExecutorDefinitionServlet.java:609)
```

The above happens when the test's `startAndEndTimes` HashMap is modified by the test's Trigger.getNextRunTime implementation at the same time the test attempts to iterate it.  The test needs to be corrected to use a thread-safe data structure for this pattern.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>